### PR TITLE
Add inline editing, hotkeys, and export upgrades

### DIFF
--- a/src/components/BacklogList.module.css
+++ b/src/components/BacklogList.module.css
@@ -12,7 +12,8 @@
 .header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  gap: 12px;
   margin-bottom: 12px;
 }
 
@@ -25,6 +26,23 @@
 .count {
   color: #64748b;
   font-size: 13px;
+  display: block;
+  margin-top: 4px;
+}
+
+.checkboxLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #475569;
+  user-select: none;
+  cursor: pointer;
+}
+
+.checkboxLabel input {
+  width: 16px;
+  height: 16px;
 }
 
 .list {

--- a/src/components/BacklogList.tsx
+++ b/src/components/BacklogList.tsx
@@ -6,12 +6,23 @@ import styles from './BacklogList.module.css';
 
 interface BacklogListProps {
   tasks: Task[];
+  totalCount?: number;
+  hideCompleted: boolean;
+  onHideCompletedChange: (value: boolean) => void;
   onDropTask: (taskId: string) => void;
-  onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null }) => void;
+  onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
 }
 
-export function BacklogList({ tasks, onDropTask, onUpdateTask }: BacklogListProps) {
+export function BacklogList({
+  tasks,
+  totalCount,
+  hideCompleted,
+  onHideCompletedChange,
+  onDropTask,
+  onUpdateTask,
+}: BacklogListProps) {
   const [isDragOver, setIsDragOver] = useState(false);
+  const displayedCount = totalCount ?? tasks.length;
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -37,8 +48,18 @@ export function BacklogList({ tasks, onDropTask, onUpdateTask }: BacklogListProp
   return (
     <section className={styles.container}>
       <div className={styles.header}>
-        <h2 className={styles.title}>Бэклог</h2>
-        <span className={styles.count}>{tasks.length}</span>
+        <div>
+          <h2 className={styles.title}>Бэклог</h2>
+          <span className={styles.count}>{displayedCount}</span>
+        </div>
+        <label className={styles.checkboxLabel}>
+          <input
+            type="checkbox"
+            checked={hideCompleted}
+            onChange={(event) => onHideCompletedChange(event.target.checked)}
+          />
+          Скрыть выполненные
+        </label>
       </div>
       <div
         className={`${styles.list} ${isDragOver ? styles.dragOver : ''}`}
@@ -47,7 +68,11 @@ export function BacklogList({ tasks, onDropTask, onUpdateTask }: BacklogListProp
         onDrop={handleDrop}
       >
         {tasks.length === 0 ? (
-          <div className={styles.empty}>Все задачи распределены по квадрантам</div>
+          <div className={styles.empty}>
+            {hideCompleted
+              ? 'Нет задач для отображения. Попробуйте отключить фильтр «Скрыть выполненные».'
+              : 'Все задачи распределены по квадрантам'}
+          </div>
         ) : (
           tasks.map((task) => (
             <TaskCard key={task.id} task={task} onUpdate={onUpdateTask} />

--- a/src/components/ImportPanel.tsx
+++ b/src/components/ImportPanel.tsx
@@ -41,7 +41,7 @@ export function ImportPanel({ value, onChange, onImport, onExport, feedback, err
         id="import-json"
         ref={textareaRef}
         className={styles.textarea}
-        placeholder='{"Task title": "1. 10. 2025 at 0:00"}'
+        placeholder='{"version":2,"tasks":{"Task":{"title":"Task","due":"1. 10. 2025 at 0:00","quadrant":"Q1","done":false}}}'
         value={value}
         onChange={(event) => onChange(event.target.value)}
       />
@@ -58,7 +58,7 @@ export function ImportPanel({ value, onChange, onImport, onExport, feedback, err
         </div>
         <div className={styles.buttons}>
           <button className={styles.secondaryButton} type="button" onClick={handleExport}>
-            Экспорт
+            Экспорт JSON
           </button>
           <button
             className={styles.primaryButton}

--- a/src/components/QuadrantBoard.tsx
+++ b/src/components/QuadrantBoard.tsx
@@ -20,7 +20,7 @@ const QUADRANT_DETAILS: Array<{
 interface QuadrantBoardProps {
   quadrants: Record<QuadrantId, Task[]>;
   onDropTask: (taskId: string, quadrant: QuadrantId) => void;
-  onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null }) => void;
+  onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
   onResetTask: (taskId: string) => void;
 }
 
@@ -38,7 +38,7 @@ function QuadrantZone({
   subtitle: string;
   tasks: Task[];
   onDrop: (taskId: string, quadrant: QuadrantId) => void;
-  onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null }) => void;
+  onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
   onResetTask: (taskId: string) => void;
 }) {
   const [isDragOver, setIsDragOver] = useState(false);

--- a/src/components/TaskCard.module.css
+++ b/src/components/TaskCard.module.css
@@ -7,6 +7,7 @@
   box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
   cursor: grab;
   transition: box-shadow 0.2s ease, transform 0.2s ease;
+  outline: none;
 }
 
 .card:active {
@@ -14,27 +15,74 @@
   transform: scale(0.98);
 }
 
+.card:focus-visible {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.cardDone {
+  opacity: 0.75;
+}
+
 .header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
 }
 
-.title {
+.doneToggle {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  margin-top: 2px;
+}
+
+.doneToggle input {
+  width: 16px;
+  height: 16px;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.titleArea {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.titleButton {
+  background: none;
+  border: none;
+  padding: 0;
   font-size: 15px;
   font-weight: 600;
-  margin: 0;
   color: #0f172a;
+  text-align: left;
+  cursor: text;
   word-break: break-word;
 }
 
-.actions {
-  display: flex;
-  gap: 8px;
+.titleButton:hover {
+  text-decoration: underline;
 }
 
-.actionButton {
+.titleDone {
+  color: #64748b;
+  text-decoration: line-through;
+}
+
+.backlogButton {
   background: transparent;
   border: none;
   color: #2563eb;
@@ -42,52 +90,58 @@
   padding: 4px 6px;
   border-radius: 6px;
   cursor: pointer;
+  flex-shrink: 0;
 }
 
-.actionButton:hover {
+.backlogButton:hover {
   background: rgba(37, 99, 235, 0.08);
 }
 
-.due {
-  font-size: 13px;
-  color: #475569;
-  margin-top: 8px;
-}
-
-.editForm {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
+.dueRow {
   margin-top: 12px;
 }
 
+.dueButton {
+  background: transparent;
+  border: none;
+  color: #475569;
+  font-size: 13px;
+  padding: 0;
+  cursor: text;
+  text-align: left;
+}
+
+.dueButton:hover {
+  color: #2563eb;
+}
+
+.fieldGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 .input {
-  padding: 8px 10px;
+  padding: 6px 8px;
   border: 1px solid #cbd5f5;
   border-radius: 8px;
   font-size: 13px;
 }
 
-.formActions {
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
+.input:focus {
+  outline: 2px solid rgba(37, 99, 235, 0.2);
+  border-color: #2563eb;
 }
 
-.saveButton {
-  background: #2563eb;
-  border: none;
-  border-radius: 8px;
-  color: #ffffff;
-  padding: 6px 12px;
-  font-weight: 600;
-  cursor: pointer;
+.inputError {
+  border-color: #f87171;
 }
 
-.cancelButton {
-  background: transparent;
-  border: none;
-  color: #64748b;
-  padding: 6px 12px;
-  cursor: pointer;
+.error {
+  font-size: 12px;
+  color: #dc2626;
+}
+
+.cardDone .dueButton {
+  color: #94a3b8;
 }

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -1,106 +1,247 @@
-import { FormEvent, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Task } from '../types';
-import { formatDate } from '../utils/date';
+import { formatDate, parseLooseDate } from '../utils/date';
 import { setTaskDragData } from '../utils/dnd';
 import styles from './TaskCard.module.css';
 
 interface TaskCardProps {
   task: Task;
-  onUpdate?: (taskId: string, updates: { title?: string; due?: string | null }) => void;
+  onUpdate?: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
   onReset?: (taskId: string) => void;
 }
 
 export function TaskCard({ task, onUpdate, onReset }: TaskCardProps) {
-  const [isEditing, setIsEditing] = useState(false);
+  const [editingField, setEditingField] = useState<'title' | 'due' | null>(null);
   const [draftTitle, setDraftTitle] = useState(task.title);
   const [draftDue, setDraftDue] = useState(task.due ?? '');
+  const [titleError, setTitleError] = useState<string | null>(null);
+  const [dueError, setDueError] = useState<string | null>(null);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const dueInputRef = useRef<HTMLInputElement>(null);
+  const done = task.done ?? false;
+
+  useEffect(() => {
+    if (editingField !== 'title') {
+      setDraftTitle(task.title);
+    }
+  }, [editingField, task.title]);
+
+  useEffect(() => {
+    if (editingField !== 'due') {
+      setDraftDue(task.due ?? '');
+    }
+  }, [editingField, task.due]);
+
+  useEffect(() => {
+    if (editingField === 'title') {
+      const input = titleInputRef.current;
+      input?.focus();
+      input?.select();
+    } else if (editingField === 'due') {
+      const input = dueInputRef.current;
+      input?.focus();
+      input?.select();
+    }
+  }, [editingField]);
 
   const handleDragStart = (event: React.DragEvent<HTMLDivElement>) => {
+    if (editingField) {
+      event.preventDefault();
+      return;
+    }
     setTaskDragData(event, task.id);
   };
 
-  const handleEdit = () => {
-    setDraftTitle(task.title);
-    setDraftDue(task.due ?? '');
-    setIsEditing(true);
-  };
-
-  const handleCancel = () => {
-    setIsEditing(false);
-  };
-
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
+  const startTitleEditing = () => {
     if (!onUpdate) {
-      setIsEditing(false);
       return;
     }
-
-    onUpdate(task.id, {
-      title: draftTitle.trim() || task.id,
-      due: draftDue,
-    });
-    setIsEditing(false);
+    setEditingField('title');
+    setTitleError(null);
   };
 
-  const handleMouseDown = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const startDueEditing = () => {
+    if (!onUpdate) {
+      return;
+    }
+    setEditingField('due');
+    setDueError(null);
+  };
+
+  const commitTitle = () => {
+    if (!onUpdate) {
+      setEditingField(null);
+      return true;
+    }
+
+    const value = draftTitle.trim();
+    if (!value) {
+      setTitleError('Название не может быть пустым');
+      return false;
+    }
+
+    if (value !== task.title) {
+      onUpdate(task.id, { title: value });
+    }
+
+    setTitleError(null);
+    setEditingField(null);
+    return true;
+  };
+
+  const commitDue = () => {
+    if (!onUpdate) {
+      setEditingField(null);
+      return true;
+    }
+
+    const value = draftDue.trim();
+    if (!value) {
+      if (task.due) {
+        onUpdate(task.id, { due: null });
+      }
+      setDueError(null);
+      setEditingField(null);
+      return true;
+    }
+
+    if (!parseLooseDate(value)) {
+      setDueError('Используйте формат DD. M. YYYY at HH:MM');
+      return false;
+    }
+
+    if (value !== (task.due ?? '')) {
+      onUpdate(task.id, { due: value });
+    }
+
+    setDueError(null);
+    setEditingField(null);
+    return true;
+  };
+
+  const cancelTitleEditing = () => {
+    setDraftTitle(task.title);
+    setTitleError(null);
+    setEditingField(null);
+  };
+
+  const cancelDueEditing = () => {
+    setDraftDue(task.due ?? '');
+    setDueError(null);
+    setEditingField(null);
+  };
+
+  const handleTitleBlur = () => {
+    if (!commitTitle()) {
+      window.setTimeout(() => titleInputRef.current?.focus(), 0);
+    }
+  };
+
+  const handleDueBlur = () => {
+    if (!commitDue()) {
+      window.setTimeout(() => dueInputRef.current?.focus(), 0);
+    }
+  };
+
+  const handleTitleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitTitle();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelTitleEditing();
+    }
+  };
+
+  const handleDueKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitDue();
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelDueEditing();
+    }
+  };
+
+  const handleDoneChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    onUpdate?.(task.id, { done: event.target.checked });
+  };
+
+  const handleBacklogMouseDown = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
   };
 
   return (
-    <div className={styles.card} draggable={!isEditing} onDragStart={handleDragStart}>
+    <div
+      className={`${styles.card} ${done ? styles.cardDone : ''}`.trim()}
+      draggable={!editingField}
+      onDragStart={handleDragStart}
+      tabIndex={0}
+      data-task-id={task.id}
+      data-quadrant={task.quadrant}
+    >
       <div className={styles.header}>
-        <h3 className={styles.title}>{task.title}</h3>
-        <div className={styles.actions}>
-          {onReset && task.quadrant !== 'backlog' ? (
+        <label className={styles.doneToggle}>
+          <input type="checkbox" checked={done} onChange={handleDoneChange} />
+          <span className={styles.visuallyHidden}>Пометить выполненной</span>
+        </label>
+        <div className={styles.titleArea}>
+          {editingField === 'title' ? (
+            <>
+              <input
+                ref={titleInputRef}
+                className={`${styles.input} ${titleError ? styles.inputError : ''}`.trim()}
+                value={draftTitle}
+                onChange={(event) => setDraftTitle(event.target.value)}
+                onBlur={handleTitleBlur}
+                onKeyDown={handleTitleKeyDown}
+                placeholder="Название задачи"
+                data-task-editor="title"
+              />
+              {titleError ? <div className={styles.error}>{titleError}</div> : null}
+            </>
+          ) : (
             <button
               type="button"
-              className={styles.actionButton}
-              onMouseDown={handleMouseDown}
-              onClick={() => onReset(task.id)}
+              className={`${styles.titleButton} ${done ? styles.titleDone : ''}`.trim()}
+              onClick={startTitleEditing}
             >
-              В бэклог
+              {task.title}
             </button>
-          ) : null}
-          {onUpdate ? (
-            <button
-              type="button"
-              className={styles.actionButton}
-              onMouseDown={handleMouseDown}
-              onClick={handleEdit}
-            >
-              Редактировать
-            </button>
-          ) : null}
+          )}
         </div>
+        {onReset && task.quadrant !== 'backlog' ? (
+          <button
+            type="button"
+            className={styles.backlogButton}
+            onMouseDown={handleBacklogMouseDown}
+            onClick={() => onReset(task.id)}
+          >
+            ↩︎ В бэклог
+          </button>
+        ) : null}
       </div>
-      <div className={styles.due}>{formatDate(task.due)}</div>
-
-      {isEditing ? (
-        <form className={styles.editForm} onSubmit={handleSubmit}>
-          <input
-            className={styles.input}
-            value={draftTitle}
-            onChange={(event) => setDraftTitle(event.target.value)}
-            placeholder="Название задачи"
-            autoFocus
-          />
-          <input
-            className={styles.input}
-            value={draftDue}
-            onChange={(event) => setDraftDue(event.target.value)}
-            placeholder="Дата: 1. 10. 2025 at 0:00"
-          />
-          <div className={styles.formActions}>
-            <button type="button" className={styles.cancelButton} onClick={handleCancel}>
-              Отмена
-            </button>
-            <button type="submit" className={styles.saveButton}>
-              Сохранить
-            </button>
+      <div className={styles.dueRow}>
+        {editingField === 'due' ? (
+          <div className={styles.fieldGroup}>
+            <input
+              ref={dueInputRef}
+              className={`${styles.input} ${dueError ? styles.inputError : ''}`.trim()}
+              value={draftDue}
+              onChange={(event) => setDraftDue(event.target.value)}
+              onBlur={handleDueBlur}
+              onKeyDown={handleDueKeyDown}
+              placeholder="1. 10. 2025 at 0:00"
+              data-task-editor="due"
+            />
+            {dueError ? <div className={styles.error}>{dueError}</div> : null}
           </div>
-        </form>
-      ) : null}
+        ) : (
+          <button type="button" className={styles.dueButton} onClick={startDueEditing}>
+            {task.due ? formatDate(task.due) : 'Без даты'}
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/hooks/useTaskStore.ts
+++ b/src/hooks/useTaskStore.ts
@@ -20,6 +20,22 @@ function normalizeDue(value: string | null | undefined): string | null {
   return trimmed.length === 0 ? null : trimmed;
 }
 
+function isQuadrant(value: unknown): value is Quadrant {
+  return value === 'backlog' || value === 'Q1' || value === 'Q2' || value === 'Q3' || value === 'Q4';
+}
+
+function isExportPayload(
+  value: unknown,
+): value is { tasks: Record<string, { title?: string; due?: string | null; quadrant?: Quadrant; done?: boolean }> } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'tasks' in value &&
+    typeof (value as { tasks: unknown }).tasks === 'object' &&
+    (value as { tasks: unknown }).tasks !== null
+  );
+}
+
 export function useTaskStore() {
   const loadRef = useRef(loadState());
   const [tasks, setTasks] = useState<TaskMap>(loadRef.current.tasks);
@@ -41,51 +57,99 @@ export function useTaskStore() {
       }
 
       if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
-        throw new Error('Ожидается объект вида { "task": "date" }');
-      }
-
-      const entries = Object.entries(payload);
-      if (entries.some(([, value]) => typeof value !== 'string')) {
-        throw new Error('Каждое значение должно быть строкой (может быть пустой).');
+        throw new Error('Ожидается объект вида { "task": "date" } или экспортированный JSON.');
       }
 
       let added = 0;
       let updated = 0;
 
-      setTasks((prev) => {
-        const base: TaskMap = {};
+      if (isExportPayload(payload)) {
+        const entries = Object.entries(payload.tasks);
 
-        if (resetQuadrants) {
-          Object.entries(prev).forEach(([id, task]) => {
-            base[id] = { ...task, quadrant: 'backlog' };
-          });
-        } else {
-          Object.assign(base, prev);
-        }
+        setTasks((prev) => {
+          const base: TaskMap = {};
 
-        for (const [id, dueValue] of entries) {
-          const due = normalizeDue(dueValue as string);
-          const existing = base[id];
-          if (existing) {
-            base[id] = {
-              ...existing,
-              title: id,
-              due,
-            };
-            updated += 1;
+          if (resetQuadrants) {
+            Object.entries(prev).forEach(([id, task]) => {
+              base[id] = { ...task, quadrant: 'backlog', done: task.done ?? false };
+            });
           } else {
+            Object.assign(base, prev);
+          }
+
+          for (const [id, descriptor] of entries) {
+            if (!descriptor || typeof descriptor !== 'object') {
+              continue;
+            }
+
+            const normalizedTitle =
+              typeof descriptor.title === 'string' && descriptor.title.trim().length > 0
+                ? descriptor.title.trim()
+                : id;
+            const normalizedDue = normalizeDue(descriptor.due ?? null);
+            const normalizedQuadrant = isQuadrant(descriptor.quadrant) ? descriptor.quadrant : 'backlog';
+            const normalizedDone = typeof descriptor.done === 'boolean' ? descriptor.done : false;
+
+            const existing = base[id];
+            if (existing) {
+              updated += 1;
+            } else {
+              added += 1;
+            }
+
             base[id] = {
               id,
-              title: id,
-              due,
-              quadrant: 'backlog',
+              title: normalizedTitle,
+              due: normalizedDue,
+              quadrant: normalizedQuadrant,
+              done: normalizedDone,
             };
-            added += 1;
           }
+
+          return base;
+        });
+      } else {
+        const entries = Object.entries(payload);
+        if (entries.some(([, value]) => typeof value !== 'string')) {
+          throw new Error('Каждое значение должно быть строкой (может быть пустой).');
         }
 
-        return base;
-      });
+        setTasks((prev) => {
+          const base: TaskMap = {};
+
+          if (resetQuadrants) {
+            Object.entries(prev).forEach(([id, task]) => {
+              base[id] = { ...task, quadrant: 'backlog', done: task.done ?? false };
+            });
+          } else {
+            Object.assign(base, prev);
+          }
+
+          for (const [id, dueValue] of entries) {
+            const due = normalizeDue(dueValue as string);
+            const existing = base[id];
+            if (existing) {
+              base[id] = {
+                ...existing,
+                title: id,
+                due,
+              };
+              updated += 1;
+            } else {
+              base[id] = {
+                id,
+                title: id,
+                due,
+                quadrant: 'backlog',
+                done: false,
+              };
+              added += 1;
+            }
+          }
+
+          return base;
+        });
+      }
 
       return { added, updated, total: added + updated };
     },
@@ -105,7 +169,7 @@ export function useTaskStore() {
     });
   }, []);
 
-  const updateTask = useCallback((taskId: string, updates: Partial<Pick<Task, 'title' | 'due'>>) => {
+  const updateTask = useCallback((taskId: string, updates: Partial<Pick<Task, 'title' | 'due' | 'done'>>) => {
     setTasks((prev) => {
       const current = prev[taskId];
       if (!current) {
@@ -115,6 +179,7 @@ export function useTaskStore() {
         ...current,
         ...updates,
         due: updates.due !== undefined ? normalizeDue(updates.due) : current.due,
+        done: updates.done !== undefined ? updates.done : current.done ?? false,
       };
       return {
         ...prev,

--- a/src/test/storage.test.ts
+++ b/src/test/storage.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { loadState, saveState } from '../utils/storage';
+import type { TaskMap } from '../types';
+
+const STORAGE_KEY = 'eisenhower_state_v1';
+const BACKUP_KEY = `${STORAGE_KEY}_backup_v1`;
+
+describe('storage migration', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('migrates version 1 payload to version 2 with done flag', () => {
+    const legacyPayload = {
+      version: 1,
+      tasks: {
+        foo: { id: 'foo', title: 'Foo task', quadrant: 'Q2' },
+      },
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(legacyPayload));
+
+    const { tasks, error } = loadState();
+    expect(error).toBeUndefined();
+    expect(tasks.foo).toMatchObject({
+      id: 'foo',
+      title: 'Foo task',
+      quadrant: 'Q2',
+      done: false,
+    });
+    expect(window.localStorage.getItem(BACKUP_KEY)).toBe(JSON.stringify(legacyPayload));
+  });
+
+  it('wraps raw task map payload without version', () => {
+    const rawMap = {
+      foo: { id: 'foo', title: 'Foo', quadrant: 'Q3' },
+    } satisfies TaskMap;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(rawMap));
+
+    const { tasks } = loadState();
+    expect(tasks.foo).toMatchObject({
+      id: 'foo',
+      title: 'Foo',
+      quadrant: 'Q3',
+      done: false,
+    });
+    expect(window.localStorage.getItem(BACKUP_KEY)).toBe(JSON.stringify(rawMap));
+  });
+
+  it('persists version 2 payload on save', () => {
+    const tasks: TaskMap = {
+      foo: { id: 'foo', title: 'Foo', quadrant: 'Q1', done: true },
+    };
+
+    saveState(tasks);
+
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(String(stored));
+    expect(parsed).toMatchObject({ version: 2, tasks: { foo: { done: true } } });
+  });
+});

--- a/src/test/taskStore.test.ts
+++ b/src/test/taskStore.test.ts
@@ -1,0 +1,91 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useTaskStore } from '../hooks/useTaskStore';
+import { createExportPayload } from '../utils/export';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.runAllTimers();
+  vi.useRealTimers();
+});
+
+describe('useTaskStore importTasks', () => {
+  it('imports structured export payload preserving metadata', () => {
+    const { result } = renderHook(() => useTaskStore());
+
+    const payload = {
+      version: 2,
+      exportedAt: '2024-01-01T00:00:00.000Z',
+      tasks: {
+        foo: { title: 'Foo', due: '1. 10. 2025 at 0:00', quadrant: 'Q2', done: true },
+      },
+    };
+
+    act(() => {
+      const summary = result.current.importTasks(JSON.stringify(payload), { resetQuadrants: false });
+      expect(summary).toMatchObject({ added: 1, updated: 0, total: 1 });
+    });
+
+    const task = result.current.tasks.foo;
+    expect(task).toBeDefined();
+    expect(task).toMatchObject({
+      id: 'foo',
+      title: 'Foo',
+      due: '1. 10. 2025 at 0:00',
+      quadrant: 'Q2',
+      done: true,
+    });
+  });
+
+  it('supports legacy flat map import and resets quadrants when requested', () => {
+    const { result } = renderHook(() => useTaskStore());
+
+    act(() => {
+      result.current.importTasks(JSON.stringify({ foo: '1. 10. 2025 at 0:00' }), { resetQuadrants: false });
+      result.current.moveTask('foo', 'Q1');
+      result.current.updateTask('foo', { title: 'Foo original' });
+      result.current.importTasks(JSON.stringify({ foo: '' }), { resetQuadrants: true });
+    });
+
+    const task = result.current.tasks.foo;
+    expect(task).toMatchObject({
+      id: 'foo',
+      title: 'foo',
+      due: null,
+      quadrant: 'backlog',
+      done: false,
+    });
+  });
+
+  it('restores state from exported payload without data loss', () => {
+    const first = renderHook(() => useTaskStore());
+
+    act(() => {
+      first.result.current.importTasks(
+        JSON.stringify({
+          alpha: '1. 10. 2025 at 0:00',
+          beta: '',
+        }),
+        { resetQuadrants: false },
+      );
+      first.result.current.updateTask('alpha', { title: 'Important alpha', done: true });
+      first.result.current.moveTask('alpha', 'Q3');
+      first.result.current.moveTask('beta', 'Q2');
+    });
+
+    const exportPayload = createExportPayload(first.result.current.tasks, new Date('2024-01-01T00:00:00Z'));
+    const exportJson = JSON.stringify(exportPayload);
+
+    const second = renderHook(() => useTaskStore());
+
+    act(() => {
+      second.result.current.importTasks(exportJson, { resetQuadrants: false });
+    });
+
+    expect(second.result.current.tasks).toEqual(first.result.current.tasks);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Task {
   title: string;
   due?: string | null;
   quadrant: Quadrant;
+  done?: boolean;
 }
 
 export type TaskMap = Record<string, Task>;

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,0 +1,33 @@
+import { Quadrant, TaskMap } from '../types';
+
+export interface ExportedTaskSnapshot {
+  title: string;
+  due: string | null;
+  quadrant: Quadrant;
+  done: boolean;
+}
+
+export interface ExportPayloadV2 {
+  version: 2;
+  exportedAt: string;
+  tasks: Record<string, ExportedTaskSnapshot>;
+}
+
+export function createExportPayload(tasks: TaskMap, exportedAt: Date = new Date()): ExportPayloadV2 {
+  const snapshot: Record<string, ExportedTaskSnapshot> = {};
+
+  Object.values(tasks).forEach((task) => {
+    snapshot[task.id] = {
+      title: task.title,
+      due: task.due ?? null,
+      quadrant: task.quadrant,
+      done: task.done ?? false,
+    };
+  });
+
+  return {
+    version: 2,
+    exportedAt: exportedAt.toISOString(),
+    tasks: snapshot,
+  };
+}


### PR DESCRIPTION
## Summary
- add inline editing for task title and due date with validation, plus a done checkbox and backlog filter
- support state migration to versioned storage, structured export/import, and JSON download naming
- wire up keyboard shortcuts and a backlog return button across backlog and quadrants

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbda033844833286ac05584f137de2