### PR TITLE
feat: polish UI and add manual task creation

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,41 +1,53 @@
 .app {
-  padding: 24px;
+  padding: clamp(20px, 4vw, 48px);
   display: flex;
   flex-direction: column;
-  gap: 24px;
-  max-width: 1200px;
+  gap: 28px;
+  max-width: 1280px;
   margin: 0 auto;
 }
 
 .topRow {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
 }
 
 @media (min-width: 960px) {
   .topRow {
     display: grid;
-    grid-template-columns: 1.2fr 1fr;
-    gap: 24px;
+    grid-template-columns: 1.1fr 1fr;
+    align-items: start;
+    gap: 28px;
   }
+}
+
+.sideColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .boardRow {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 28px;
+  align-items: center;
 }
 
 .alert {
-  padding: 12px 16px;
-  border-radius: 12px;
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fecaca;
+  padding: 14px 18px;
+  border-radius: 16px;
+  background: rgba(254, 226, 226, 0.82);
+  color: #7f1d1d;
+  border: 1px solid rgba(254, 202, 202, 0.86);
+  box-shadow: 0 18px 36px -28px rgba(127, 29, 29, 0.55);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
 }
 
 .hotkeysHint {
   font-size: 12px;
-  color: #94a3b8;
+  color: rgba(15, 23, 42, 0.55);
+  margin: 0;
 }

--- a/src/components/BacklogList.module.css
+++ b/src/components/BacklogList.module.css
@@ -1,12 +1,14 @@
 .container {
-  background: #ffffff;
-  border-radius: 16px;
-  border: 1px solid #dde4f2;
-  padding: 16px;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.32);
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  padding: 18px;
+  box-shadow: 0 28px 56px -40px rgba(15, 23, 42, 0.45);
   display: flex;
   flex-direction: column;
-  min-height: 300px;
+  min-height: 320px;
+  backdrop-filter: blur(28px) saturate(140%);
+  -webkit-backdrop-filter: blur(28px) saturate(140%);
 }
 
 .header {
@@ -14,17 +16,18 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
-  margin-bottom: 12px;
+  margin-bottom: 14px;
 }
 
 .title {
   font-size: 18px;
   font-weight: 700;
   margin: 0;
+  color: rgba(15, 23, 42, 0.9);
 }
 
 .count {
-  color: #64748b;
+  color: rgba(14, 116, 144, 0.9);
   font-size: 13px;
   display: block;
   margin-top: 4px;
@@ -35,7 +38,7 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: #475569;
+  color: rgba(15, 23, 42, 0.65);
   user-select: none;
   cursor: pointer;
 }
@@ -47,20 +50,22 @@
 
 .list {
   flex: 1;
-  min-height: 200px;
-  padding: 4px;
-  border-radius: 12px;
-  border: 1px dashed transparent;
+  min-height: 220px;
+  padding: 6px;
+  border-radius: 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.2);
   transition: border-color 0.2s ease, background 0.2s ease;
+  background: rgba(255, 255, 255, 0.18);
+  overflow: auto;
 }
 
 .dragOver {
-  border-color: #2563eb;
-  background: rgba(37, 99, 235, 0.08);
+  border-color: rgba(59, 130, 246, 0.65);
+  background: rgba(59, 130, 246, 0.15);
 }
 
 .empty {
-  color: #94a3b8;
+  color: rgba(15, 23, 42, 0.6);
   font-size: 13px;
   text-align: center;
   margin-top: 24px;

--- a/src/components/ImportPanel.module.css
+++ b/src/components/ImportPanel.module.css
@@ -1,28 +1,40 @@
 .panel {
-  background: #ffffff;
-  border-radius: 16px;
-  padding: 16px;
-  border: 1px solid #dde4f2;
+  background: rgba(255, 255, 255, 0.32);
+  border-radius: 22px;
+  padding: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  gap: 14px;
+  box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(28px) saturate(140%);
+  -webkit-backdrop-filter: blur(28px) saturate(140%);
 }
 
 .label {
   font-weight: 600;
-  color: #0f172a;
+  color: rgba(15, 23, 42, 0.85);
 }
 
 .textarea {
-  min-height: 120px;
+  min-height: 140px;
   resize: vertical;
-  padding: 10px;
-  border-radius: 12px;
-  border: 1px solid #cbd5f5;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.6);
   font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
   font-size: 13px;
   line-height: 1.4;
+  color: #0f172a;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.8);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
 }
 
 .controls {
@@ -44,37 +56,55 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: #475569;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.checkboxLabel input {
+  width: 16px;
+  height: 16px;
 }
 
 .buttons {
   display: flex;
-  gap: 8px;
+  gap: 10px;
 }
 
 .primaryButton {
-  background: #2563eb;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.95), rgba(14, 165, 233, 0.85));
   color: #ffffff;
   border: none;
-  padding: 8px 16px;
-  border-radius: 10px;
+  padding: 10px 20px;
+  border-radius: 999px;
   font-weight: 600;
   cursor: pointer;
+  box-shadow: 0 12px 24px -16px rgba(37, 99, 235, 0.9);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px -20px rgba(37, 99, 235, 0.9);
 }
 
 .secondaryButton {
-  background: transparent;
-  color: #2563eb;
+  background: rgba(255, 255, 255, 0.4);
+  color: rgba(37, 99, 235, 0.9);
   border: 1px solid rgba(37, 99, 235, 0.4);
-  padding: 8px 16px;
-  border-radius: 10px;
+  padding: 10px 18px;
+  border-radius: 999px;
   font-weight: 600;
   cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.secondaryButton:hover {
+  background: rgba(37, 99, 235, 0.08);
+  color: rgba(37, 99, 235, 1);
 }
 
 .feedback {
   font-size: 13px;
-  color: #0f172a;
+  color: rgba(15, 23, 42, 0.85);
 }
 
 .error {

--- a/src/components/ManualTaskForm.module.css
+++ b/src/components/ManualTaskForm.module.css
@@ -1,0 +1,95 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.32);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.35);
+  backdrop-filter: blur(26px) saturate(140%);
+  -webkit-backdrop-filter: blur(26px) saturate(140%);
+  color: #0f172a;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.title {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.feedback {
+  font-size: 13px;
+  color: #0ea5e9;
+  font-weight: 600;
+}
+
+.label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: rgba(15, 23, 42, 0.76);
+}
+
+.input {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.58);
+  color: #0f172a;
+  font-size: 14px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.input:focus {
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.8);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+
+.input[aria-invalid='true'] {
+  border-color: rgba(248, 113, 113, 0.95);
+  box-shadow: 0 0 0 3px rgba(248, 113, 113, 0.2);
+}
+
+.select {
+  appearance: none;
+  background-image: linear-gradient(135deg, rgba(14, 165, 233, 0.35), rgba(59, 130, 246, 0.35));
+  background-blend-mode: screen;
+}
+
+.error {
+  font-size: 13px;
+  color: #ef4444;
+}
+
+.submit {
+  align-self: flex-start;
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.85), rgba(59, 130, 246, 0.65));
+  color: white;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+.submit:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px -12px rgba(37, 99, 235, 0.85);
+}

--- a/src/components/ManualTaskForm.tsx
+++ b/src/components/ManualTaskForm.tsx
@@ -1,0 +1,125 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { Quadrant } from '../types';
+import { parseLooseDate } from '../utils/date';
+import styles from './ManualTaskForm.module.css';
+
+interface ManualTaskFormProps {
+  onCreateTask: (task: { title: string; due: string | null; quadrant: Quadrant }) => void;
+}
+
+const QUADRANT_OPTIONS: Array<{ value: Quadrant; label: string }> = [
+  { value: 'backlog', label: 'Бэклог' },
+  { value: 'Q1', label: 'Q1 — Срочно + Важно' },
+  { value: 'Q2', label: 'Q2 — Несрочно + Важно' },
+  { value: 'Q3', label: 'Q3 — Срочно + Неважно' },
+  { value: 'Q4', label: 'Q4 — Несрочно + Неважно' },
+];
+
+export function ManualTaskForm({ onCreateTask }: ManualTaskFormProps) {
+  const [title, setTitle] = useState('');
+  const [due, setDue] = useState('');
+  const [quadrant, setQuadrant] = useState<Quadrant>('backlog');
+  const [error, setError] = useState<string | null>(null);
+  const [errorField, setErrorField] = useState<'title' | 'due' | null>(null);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!feedback) {
+      return;
+    }
+    const timeoutId = window.setTimeout(() => setFeedback(null), 2400);
+    return () => window.clearTimeout(timeoutId);
+  }, [feedback]);
+
+  const isSubmitDisabled = useMemo(() => !title.trim(), [title]);
+
+  const resetForm = useCallback(() => {
+    setTitle('');
+    setDue('');
+    setQuadrant('backlog');
+    setErrorField(null);
+  }, []);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const normalizedTitle = title.trim();
+    if (!normalizedTitle) {
+      setError('Введите название задачи');
+      setErrorField('title');
+      return;
+    }
+
+    const normalizedDue = due.trim();
+    if (normalizedDue && !parseLooseDate(normalizedDue)) {
+      setError('Используйте формат 1. 10. 2025 at 0:00');
+      setErrorField('due');
+      return;
+    }
+
+    setError(null);
+    setErrorField(null);
+    onCreateTask({ title: normalizedTitle, due: normalizedDue || null, quadrant });
+    resetForm();
+    setFeedback('Задача добавлена');
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>Быстрое добавление</h2>
+        {feedback ? <span className={styles.feedback}>{feedback}</span> : null}
+      </div>
+      <label className={styles.label}>
+        Название
+        <input
+          className={styles.input}
+          value={title}
+          onChange={(event) => {
+            if (errorField === 'title') {
+              setError(null);
+              setErrorField(null);
+            }
+            setTitle(event.target.value);
+          }}
+          placeholder="Например, созвониться с клиентом"
+          aria-invalid={errorField === 'title' ? 'true' : 'false'}
+        />
+      </label>
+      <label className={styles.label}>
+        Дата и время
+        <input
+          className={styles.input}
+          value={due}
+          onChange={(event) => {
+            if (errorField === 'due') {
+              setError(null);
+              setErrorField(null);
+            }
+            setDue(event.target.value);
+          }}
+          placeholder="1. 10. 2025 at 0:00"
+          aria-invalid={errorField === 'due' ? 'true' : 'false'}
+        />
+      </label>
+      <label className={styles.label}>
+        Квадрант
+        <select
+          className={`${styles.input} ${styles.select}`.trim()}
+          value={quadrant}
+          onChange={(event) => setQuadrant(event.target.value as Quadrant)}
+        >
+          {QUADRANT_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+      {error ? <div className={styles.error}>{error}</div> : null}
+      <button type="submit" className={styles.submit} disabled={isSubmitDisabled}>
+        Добавить задачу
+      </button>
+    </form>
+  );
+}

--- a/src/components/QuadrantBoard.module.css
+++ b/src/components/QuadrantBoard.module.css
@@ -1,18 +1,28 @@
 .board {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 16px;
+  gap: 24px;
+  justify-content: center;
+  grid-template-columns: minmax(260px, 1fr);
+  width: min(100%, 760px);
+}
+
+@media (min-width: 768px) {
+  .board {
+    grid-template-columns: repeat(2, minmax(280px, 360px));
+  }
 }
 
 .zone {
-  background: #ffffff;
-  border-radius: 16px;
-  border: 1px solid #dde4f2;
-  padding: 16px;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
-  min-height: 220px;
+  background: rgba(255, 255, 255, 0.28);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  padding: 18px;
+  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.5);
+  min-height: 280px;
   display: flex;
   flex-direction: column;
+  backdrop-filter: blur(30px) saturate(140%);
+  -webkit-backdrop-filter: blur(30px) saturate(140%);
 }
 
 .zoneHeader {
@@ -23,29 +33,32 @@
   margin: 0;
   font-size: 17px;
   font-weight: 700;
+  color: rgba(15, 23, 42, 0.9);
 }
 
 .zoneSubtitle {
   margin: 4px 0 0;
   font-size: 13px;
-  color: #64748b;
+  color: rgba(15, 23, 42, 0.55);
 }
 
 .dropArea {
   flex: 1;
-  border-radius: 12px;
-  border: 1px dashed transparent;
-  padding: 4px;
+  border-radius: 18px;
+  border: 1px dashed rgba(255, 255, 255, 0.24);
+  padding: 8px;
   transition: border-color 0.2s ease, background 0.2s ease;
+  background: rgba(255, 255, 255, 0.16);
+  overflow: auto;
 }
 
 .dragOver {
-  border-color: #16a34a;
-  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(56, 189, 248, 0.8);
+  background: rgba(56, 189, 248, 0.18);
 }
 
 .emptyState {
-  color: #94a3b8;
+  color: rgba(15, 23, 42, 0.6);
   font-size: 13px;
   text-align: center;
   margin-top: 24px;

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -2,11 +2,13 @@
   display: flex;
   gap: 12px;
   align-items: center;
-  background: #ffffff;
-  border-radius: 12px;
-  padding: 12px 16px;
-  border: 1px solid #dde4f2;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.28);
+  border-radius: 18px;
+  padding: 14px 18px;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  box-shadow: 0 20px 40px -32px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(26px) saturate(140%);
+  -webkit-backdrop-filter: blur(26px) saturate(140%);
 }
 
 .searchInput {
@@ -15,12 +17,21 @@
   outline: none;
   font-size: 14px;
   color: #0f172a;
+  background: transparent;
 }
 
 .clearButton {
-  background: transparent;
+  background: rgba(37, 99, 235, 0.1);
   border: none;
-  color: #2563eb;
+  color: rgba(37, 99, 235, 0.9);
   cursor: pointer;
   font-weight: 600;
+  padding: 8px 16px;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.clearButton:hover {
+  background: rgba(37, 99, 235, 0.18);
+  color: rgba(37, 99, 235, 1);
 }

--- a/src/components/TaskCard.module.css
+++ b/src/components/TaskCard.module.css
@@ -1,13 +1,15 @@
 .card {
-  background: #ffffff;
-  border: 1px solid #e0e6f0;
-  border-radius: 12px;
-  padding: 12px 14px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  border-radius: 18px;
+  padding: 14px 16px;
   margin-bottom: 12px;
-  box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.55);
   cursor: grab;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
   outline: none;
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
 }
 
 .card:active {
@@ -16,11 +18,11 @@
 }
 
 .card:focus-visible {
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25);
 }
 
 .cardDone {
-  opacity: 0.75;
+  opacity: 0.7;
 }
 
 .header {
@@ -67,7 +69,7 @@
   padding: 0;
   font-size: 15px;
   font-weight: 600;
-  color: #0f172a;
+  color: rgba(15, 23, 42, 0.92);
   text-align: left;
   cursor: text;
   word-break: break-word;
@@ -78,23 +80,25 @@
 }
 
 .titleDone {
-  color: #64748b;
+  color: rgba(15, 23, 42, 0.55);
   text-decoration: line-through;
 }
 
 .backlogButton {
-  background: transparent;
+  background: rgba(37, 99, 235, 0.1);
   border: none;
-  color: #2563eb;
+  color: rgba(37, 99, 235, 0.95);
   font-size: 13px;
-  padding: 4px 6px;
-  border-radius: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
   cursor: pointer;
   flex-shrink: 0;
+  transition: background 0.2s ease, color 0.2s ease;
 }
 
 .backlogButton:hover {
-  background: rgba(37, 99, 235, 0.08);
+  background: rgba(37, 99, 235, 0.2);
+  color: rgba(37, 99, 235, 1);
 }
 
 .dueRow {
@@ -102,17 +106,20 @@
 }
 
 .dueButton {
-  background: transparent;
-  border: none;
-  color: #475569;
+  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  color: rgba(15, 23, 42, 0.65);
   font-size: 13px;
-  padding: 0;
+  padding: 6px 10px;
+  border-radius: 999px;
   cursor: text;
   text-align: left;
+  transition: border-color 0.2s ease, color 0.2s ease;
 }
 
 .dueButton:hover {
-  color: #2563eb;
+  border-color: rgba(37, 99, 235, 0.6);
+  color: rgba(37, 99, 235, 0.9);
 }
 
 .fieldGroup {
@@ -122,19 +129,23 @@
 }
 
 .input {
-  padding: 6px 8px;
-  border: 1px solid #cbd5f5;
-  border-radius: 8px;
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 10px;
   font-size: 13px;
+  background: rgba(255, 255, 255, 0.72);
+  color: #0f172a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .input:focus {
-  outline: 2px solid rgba(37, 99, 235, 0.2);
-  border-color: #2563eb;
+  outline: none;
+  border-color: rgba(59, 130, 246, 0.8);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.18);
 }
 
 .inputError {
-  border-color: #f87171;
+  border-color: rgba(248, 113, 113, 0.9);
 }
 
 .error {
@@ -143,5 +154,5 @@
 }
 
 .cardDone .dueButton {
-  color: #94a3b8;
+  color: rgba(148, 163, 184, 0.85);
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
 :root {
   color-scheme: light;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: #f6f8fb;
-  color: #1f2933;
+  color: #0f172a;
+  background-color: #e4ecff;
 }
 
 * {
@@ -11,10 +11,18 @@
 
 body {
   margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.22), transparent 45%),
+    radial-gradient(circle at 50% 100%, rgba(129, 140, 248, 0.25), transparent 55%),
+    linear-gradient(180deg, rgba(241, 245, 255, 0.9), rgba(226, 232, 255, 0.6));
+  background-attachment: fixed;
 }
 
 button,
 input,
-textarea {
+textarea,
+select {
   font: inherit;
 }

--- a/src/utils/taskSort.ts
+++ b/src/utils/taskSort.ts
@@ -1,0 +1,28 @@
+import { Task } from '../types';
+import { parseLooseDate } from './date';
+
+export function compareTasks(a: Task, b: Task): number {
+  const doneDiff = Number(a.done ?? false) - Number(b.done ?? false);
+  if (doneDiff !== 0) {
+    return doneDiff;
+  }
+
+  const dateA = parseLooseDate(a.due ?? undefined);
+  const dateB = parseLooseDate(b.due ?? undefined);
+
+  if (dateA && dateB) {
+    const diff = dateA.getTime() - dateB.getTime();
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+
+  if (dateA && !dateB) return -1;
+  if (!dateA && dateB) return 1;
+
+  return a.title.localeCompare(b.title, undefined, { sensitivity: 'accent' });
+}
+
+export function sortTasks(tasks: Task[]): Task[] {
+  return [...tasks].sort(compareTasks);
+}


### PR DESCRIPTION
## Summary
- add a quick-add form with validation and quadrant selector so tasks can be created without JSON import
- refresh the backlog, board, and utility panels with glassmorphism styling and centered 2x2 layout
- keep completed tasks at the end of each list by sharing a reusable sorting helper across backlog and quadrants

## Testing
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cbdef9a51c8332b5020c1a907ecf56