### PR TITLE
Limit quadrant height to three cards

### DIFF
--- a/src/components/QuadrantBoard.module.css
+++ b/src/components/QuadrantBoard.module.css
@@ -18,7 +18,6 @@
   border: 1px solid rgba(255, 255, 255, 0.45);
   padding: 18px;
   box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.5);
-  min-height: 280px;
   display: flex;
   flex-direction: column;
   backdrop-filter: blur(30px) saturate(140%);
@@ -50,6 +49,7 @@
   transition: border-color 0.2s ease, background 0.2s ease;
   background: rgba(255, 255, 255, 0.16);
   overflow: auto;
+  max-height: var(--quadrant-max-height, none);
 }
 
 .dragOver {

--- a/src/components/QuadrantBoard.tsx
+++ b/src/components/QuadrantBoard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { Quadrant, Task } from '../types';
 import { getTaskIdFromDrag } from '../utils/dnd';
 import { TaskCard } from './TaskCard';
@@ -42,6 +42,86 @@ function QuadrantZone({
   onResetTask: (taskId: string) => void;
 }) {
   const [isDragOver, setIsDragOver] = useState(false);
+  const dropAreaRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const dropArea = dropAreaRef.current;
+    if (!dropArea || typeof window === 'undefined') {
+      return;
+    }
+
+    const hasResizeObserver = typeof window.ResizeObserver !== 'undefined';
+    const hasMutationObserver = typeof window.MutationObserver !== 'undefined';
+
+    const updateMaxHeight = () => {
+      if (!dropArea) {
+        return;
+      }
+
+      const cards = Array.from(dropArea.querySelectorAll<HTMLElement>('[data-task-id]'));
+      const limit = Math.min(cards.length, 3);
+
+      if (limit === 0) {
+        dropArea.style.removeProperty('--quadrant-max-height');
+        return;
+      }
+
+      let totalHeight = 0;
+      for (let index = 0; index < limit; index += 1) {
+        const card = cards[index];
+        totalHeight += card.getBoundingClientRect().height;
+        if (index < limit - 1) {
+          totalHeight += parseFloat(window.getComputedStyle(card).marginBottom || '0');
+        }
+      }
+
+      const areaStyles = window.getComputedStyle(dropArea);
+      const verticalChrome =
+        parseFloat(areaStyles.paddingTop || '0') +
+        parseFloat(areaStyles.paddingBottom || '0') +
+        parseFloat(areaStyles.borderTopWidth || '0') +
+        parseFloat(areaStyles.borderBottomWidth || '0');
+
+      dropArea.style.setProperty('--quadrant-max-height', `${Math.ceil(totalHeight + verticalChrome)}px`);
+    };
+
+    updateMaxHeight();
+
+    if (!hasResizeObserver) {
+      return;
+    }
+
+    const resizeObserver = new ResizeObserver(() => {
+      updateMaxHeight();
+    });
+
+    const observeElements = () => {
+      resizeObserver.disconnect();
+      resizeObserver.observe(dropArea);
+      const cards = Array.from(dropArea.querySelectorAll<HTMLElement>('[data-task-id]'));
+      cards.forEach((card) => resizeObserver.observe(card));
+    };
+
+    observeElements();
+
+    if (hasMutationObserver) {
+      const mutationObserver = new MutationObserver(() => {
+        observeElements();
+        updateMaxHeight();
+      });
+
+      mutationObserver.observe(dropArea, { childList: true, subtree: true });
+
+      return () => {
+        resizeObserver.disconnect();
+        mutationObserver.disconnect();
+      };
+    }
+
+    return () => {
+      resizeObserver.disconnect();
+    };
+  }, [tasks]);
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -69,6 +149,7 @@ function QuadrantZone({
         <p className={styles.zoneSubtitle}>{subtitle}</p>
       </header>
       <div
+        ref={dropAreaRef}
         className={`${styles.dropArea} ${isDragOver ? styles.dragOver : ''}`.trim()}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}


### PR DESCRIPTION
## Summary
- measure the task cards in each quadrant and derive a CSS max-height that fits up to three cards
- bind the computed limit to the drop area so additional cards scroll instead of stretching the quadrant

## Testing
- npm test *(fails: missing optional dependency @rollup/rollup-linux-x64-gnu in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6786cb888332bf0da8732049e65d