### PR TITLE
feat: add date-time picker for due dates

### DIFF
--- a/src/components/ManualTaskForm.tsx
+++ b/src/components/ManualTaskForm.tsx
@@ -1,6 +1,6 @@
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import { Quadrant } from '../types';
-import { parseLooseDate } from '../utils/date';
+import { fromDateTimeLocalInput } from '../utils/date';
 import styles from './ManualTaskForm.module.css';
 
 interface ManualTaskFormProps {
@@ -51,15 +51,16 @@ export function ManualTaskForm({ onCreateTask }: ManualTaskFormProps) {
     }
 
     const normalizedDue = due.trim();
-    if (normalizedDue && !parseLooseDate(normalizedDue)) {
-      setError('Используйте формат 1. 10. 2025 at 0:00');
+    const dueIso = normalizedDue ? fromDateTimeLocalInput(normalizedDue) : null;
+    if (normalizedDue && !dueIso) {
+      setError('Выберите корректную дату и время');
       setErrorField('due');
       return;
     }
 
     setError(null);
     setErrorField(null);
-    onCreateTask({ title: normalizedTitle, due: normalizedDue || null, quadrant });
+    onCreateTask({ title: normalizedTitle, due: dueIso, quadrant });
     resetForm();
     setFeedback('Задача добавлена');
   };
@@ -89,6 +90,7 @@ export function ManualTaskForm({ onCreateTask }: ManualTaskFormProps) {
       <label className={styles.label}>
         Дата и время
         <input
+          type="datetime-local"
           className={styles.input}
           value={due}
           onChange={(event) => {
@@ -98,7 +100,7 @@ export function ManualTaskForm({ onCreateTask }: ManualTaskFormProps) {
             }
             setDue(event.target.value);
           }}
-          placeholder="1. 10. 2025 at 0:00"
+          step={60}
           aria-invalid={errorField === 'due' ? 'true' : 'false'}
         />
       </label>

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { formatDate, parseLooseDate } from './date';
+import {
+  formatDate,
+  fromDateTimeLocalInput,
+  parseLooseDate,
+  toDateTimeLocalInputValue,
+} from './date';
 
 describe('parseLooseDate', () => {
   it('parses DD. M. YYYY at HH:MM format', () => {
@@ -28,5 +33,20 @@ describe('formatDate', () => {
   it('returns placeholder for empty input', () => {
     expect(formatDate('')).toBe('Без даты');
     expect(formatDate(null)).toBe('Без даты');
+  });
+});
+
+describe('date-time local helpers', () => {
+  it('converts between ISO string and input value', () => {
+    const inputValue = '2025-10-01T15:45';
+    const isoValue = fromDateTimeLocalInput(inputValue);
+    expect(isoValue).toBeTypeOf('string');
+    expect(isoValue).not.toBeNull();
+    expect(toDateTimeLocalInputValue(isoValue)).toBe(inputValue);
+  });
+
+  it('handles invalid values', () => {
+    expect(fromDateTimeLocalInput('not a date')).toBeNull();
+    expect(toDateTimeLocalInputValue('not a date')).toBe('');
   });
 });

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,5 +1,9 @@
 const LOOSE_DATE_REGEX = /^(\d{1,2})\.\s*(\d{1,2})\.\s*(\d{4})(?:\s+at\s+(\d{1,2}):(\d{2}))?$/i;
 
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
 export function parseLooseDate(input: string | null | undefined): Date | null {
   if (!input) {
     return null;
@@ -55,4 +59,32 @@ export function formatDate(value: string | null | undefined): string {
     console.error('Failed to format date', error);
     return value;
   }
+}
+
+export function toDateTimeLocalInputValue(value: string | null | undefined): string {
+  const parsed = parseLooseDate(value);
+  if (!parsed) {
+    return '';
+  }
+
+  const year = parsed.getFullYear();
+  const month = pad(parsed.getMonth() + 1);
+  const day = pad(parsed.getDate());
+  const hours = pad(parsed.getHours());
+  const minutes = pad(parsed.getMinutes());
+
+  return `${year}-${month}-${day}T${hours}:${minutes}`;
+}
+
+export function fromDateTimeLocalInput(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = parseLooseDate(value);
+  if (!parsed) {
+    return null;
+  }
+
+  return parsed.toISOString();
 }


### PR DESCRIPTION
## Summary
- replace free-text due date fields with native datetime pickers in the task form and card editor
- normalize picker values to ISO strings for consistent storage and reuse parsed helpers to map between formats
- extend date utilities and tests to cover the new conversion helpers

## Testing
- `npm test` *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu missing in npm environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc68a0b9f48332912d3d28b1e3dcde