### PR TITLE
Fix task hydration to drop empty notes

### DIFF
--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,4 +1,5 @@
 import { Quadrant, Task, TaskMap } from '../types';
+import { sanitizeNotesHtml } from './notes';
 
 const STORAGE_KEY = 'eisenhower_state_v1';
 const BACKUP_KEY = `${STORAGE_KEY}_backup_v1`;
@@ -26,6 +27,8 @@ function withDoneFlag(tasks: Record<string, Omit<Task, 'done'> | Task | undefine
     const { done, quadrant, ...rest } = task as Task & { quadrant?: Quadrant };
     const normalizedQuadrant: Quadrant = quadrant ?? 'backlog';
 
+    const sanitizedNotes = sanitizeNotesHtml((task as Task).notes ?? null);
+
     result[id] = {
       id,
       title: rest.title ?? id,
@@ -33,6 +36,10 @@ function withDoneFlag(tasks: Record<string, Omit<Task, 'done'> | Task | undefine
       quadrant: normalizedQuadrant,
       done: done ?? false,
     };
+
+    if (sanitizedNotes) {
+      result[id].notes = sanitizedNotes;
+    }
   });
   return result;
 }


### PR DESCRIPTION
## Summary
- prevent the storage hydration helper from persisting empty note fields

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc672e8c9883328c8724c4ec60147d