### PR TITLE
Add collapsible priority and backlog sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,23 @@ import { sortTasks } from './utils/taskSort';
 
 type QuadrantId = Exclude<Quadrant, 'backlog'>;
 
+type CollapseState = {
+  backlog: boolean;
+  quadrants: Record<QuadrantId, boolean>;
+};
+
+const COLLAPSE_STORAGE_KEY = 'eisenhower_ui_prefs_v1';
+
+const DEFAULT_COLLAPSE_STATE: CollapseState = {
+  backlog: false,
+  quadrants: {
+    Q1: false,
+    Q2: false,
+    Q3: false,
+    Q4: false,
+  },
+};
+
 function filterBacklog(tasks: Task[], query: string, hideCompleted: boolean): Task[] {
   const normalized = query.trim().toLowerCase();
 
@@ -49,6 +66,11 @@ export default function App() {
   const [importError, setImportError] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [hideCompleted, setHideCompleted] = useState(false);
+  const [collapseState, setCollapseState] = useState<CollapseState>(() => ({
+    backlog: DEFAULT_COLLAPSE_STATE.backlog,
+    quadrants: { ...DEFAULT_COLLAPSE_STATE.quadrants },
+  }));
+  const [collapseLoaded, setCollapseLoaded] = useState(false);
 
   const searchInputRef = useRef<HTMLInputElement>(null);
   const importTextareaRef = useRef<HTMLTextAreaElement>(null);
@@ -131,6 +153,64 @@ export default function App() {
   const handleHideCompletedChange = useCallback((value: boolean) => {
     setHideCompleted(value);
   }, []);
+
+  const handleToggleBacklogCollapse = useCallback(() => {
+    setCollapseState((previous) => ({
+      backlog: !previous.backlog,
+      quadrants: { ...previous.quadrants },
+    }));
+  }, []);
+
+  const handleToggleQuadrantCollapse = useCallback((quadrant: QuadrantId) => {
+    setCollapseState((previous) => ({
+      backlog: previous.backlog,
+      quadrants: { ...previous.quadrants, [quadrant]: !previous.quadrants[quadrant] },
+    }));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      setCollapseLoaded(true);
+      return;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(COLLAPSE_STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<CollapseState> | null;
+        const nextQuadrants: Record<QuadrantId, boolean> = { ...DEFAULT_COLLAPSE_STATE.quadrants };
+        if (parsed?.quadrants && typeof parsed.quadrants === 'object') {
+          (Object.keys(nextQuadrants) as QuadrantId[]).forEach((quadrantId) => {
+            const value = (parsed.quadrants as Record<string, unknown>)[quadrantId];
+            if (typeof value === 'boolean') {
+              nextQuadrants[quadrantId] = value;
+            }
+          });
+        }
+
+        setCollapseState({
+          backlog: typeof parsed?.backlog === 'boolean' ? parsed.backlog : DEFAULT_COLLAPSE_STATE.backlog,
+          quadrants: nextQuadrants,
+        });
+      }
+    } catch (error) {
+      console.warn('Failed to load collapse state', error);
+    } finally {
+      setCollapseLoaded(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!collapseLoaded || typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      window.localStorage.setItem(COLLAPSE_STORAGE_KEY, JSON.stringify(collapseState));
+    } catch (error) {
+      console.warn('Failed to save collapse state', error);
+    }
+  }, [collapseLoaded, collapseState]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -254,6 +334,8 @@ export default function App() {
             onHideCompletedChange={handleHideCompletedChange}
             onDropTask={handleBacklogDrop}
             onUpdateTask={handleUpdateTask}
+            collapsed={collapseState.backlog}
+            onToggleCollapse={handleToggleBacklogCollapse}
           />
         </div>
       </div>
@@ -261,9 +343,11 @@ export default function App() {
       <div className={styles.boardRow}>
         <QuadrantBoard
           quadrants={{ Q1: quadrants.Q1 ?? [], Q2: quadrants.Q2 ?? [], Q3: quadrants.Q3 ?? [], Q4: quadrants.Q4 ?? [] }}
+          collapsed={collapseState.quadrants}
           onDropTask={handleQuadrantDrop}
           onUpdateTask={handleUpdateTask}
           onResetTask={resetTask}
+          onToggleCollapse={handleToggleQuadrantCollapse}
         />
       </div>
     </div>

--- a/src/components/BacklogList.module.css
+++ b/src/components/BacklogList.module.css
@@ -11,12 +11,30 @@
   -webkit-backdrop-filter: blur(28px) saturate(140%);
 }
 
+.collapsed {
+  min-height: auto;
+}
+
 .header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 12px;
   margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.headerTitle {
+  flex: 1;
+  min-width: 0;
+}
+
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .title {
@@ -46,6 +64,27 @@
 .checkboxLabel input {
   width: 16px;
   height: 16px;
+}
+
+.toggleButton {
+  appearance: none;
+  border: none;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.08);
+  color: rgba(15, 23, 42, 0.75);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+}
+
+.toggleButton:hover,
+.toggleButton:focus-visible {
+  background: rgba(59, 130, 246, 0.16);
+  color: rgba(37, 99, 235, 0.9);
+  outline: none;
 }
 
 .list {

--- a/src/components/BacklogList.tsx
+++ b/src/components/BacklogList.tsx
@@ -11,6 +11,8 @@ interface BacklogListProps {
   onHideCompletedChange: (value: boolean) => void;
   onDropTask: (taskId: string) => void;
   onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
+  collapsed: boolean;
+  onToggleCollapse: () => void;
 }
 
 export function BacklogList({
@@ -20,9 +22,12 @@ export function BacklogList({
   onHideCompletedChange,
   onDropTask,
   onUpdateTask,
+  collapsed,
+  onToggleCollapse,
 }: BacklogListProps) {
   const [isDragOver, setIsDragOver] = useState(false);
   const displayedCount = totalCount ?? tasks.length;
+  const listId = 'backlog-drop-area';
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -46,39 +51,53 @@ export function BacklogList({
   };
 
   return (
-    <section className={styles.container}>
+    <section className={`${styles.container} ${collapsed ? styles.collapsed : ''}`.trim()}>
       <div className={styles.header}>
-        <div>
+        <div className={styles.headerTitle}>
           <h2 className={styles.title}>Бэклог</h2>
           <span className={styles.count}>{displayedCount}</span>
         </div>
-        <label className={styles.checkboxLabel}>
-          <input
-            type="checkbox"
-            checked={hideCompleted}
-            onChange={(event) => onHideCompletedChange(event.target.checked)}
-          />
-          Скрыть выполненные
-        </label>
+        <div className={styles.headerActions}>
+          <button
+            type="button"
+            className={styles.toggleButton}
+            onClick={onToggleCollapse}
+            aria-expanded={!collapsed}
+            aria-controls={listId}
+          >
+            {collapsed ? 'Развернуть' : 'Свернуть'}
+          </button>
+          <label className={styles.checkboxLabel}>
+            <input
+              type="checkbox"
+              checked={hideCompleted}
+              onChange={(event) => onHideCompletedChange(event.target.checked)}
+            />
+            Скрыть выполненные
+          </label>
+        </div>
       </div>
-      <div
-        className={`${styles.list} ${isDragOver ? styles.dragOver : ''}`}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        {tasks.length === 0 ? (
-          <div className={styles.empty}>
-            {hideCompleted
-              ? 'Нет задач для отображения. Попробуйте отключить фильтр «Скрыть выполненные».'
-              : 'Все задачи распределены по квадрантам'}
-          </div>
-        ) : (
-          tasks.map((task) => (
-            <TaskCard key={task.id} task={task} onUpdate={onUpdateTask} />
-          ))
-        )}
-      </div>
+      {!collapsed && (
+        <div
+          id={listId}
+          className={`${styles.list} ${isDragOver ? styles.dragOver : ''}`}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {tasks.length === 0 ? (
+            <div className={styles.empty}>
+              {hideCompleted
+                ? 'Нет задач для отображения. Попробуйте отключить фильтр «Скрыть выполненные».'
+                : 'Все задачи распределены по квадрантам'}
+            </div>
+          ) : (
+            tasks.map((task) => (
+              <TaskCard key={task.id} task={task} onUpdate={onUpdateTask} />
+            ))
+          )}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/QuadrantBoard.module.css
+++ b/src/components/QuadrantBoard.module.css
@@ -25,8 +25,21 @@
   -webkit-backdrop-filter: blur(30px) saturate(140%);
 }
 
+.zoneCollapsed {
+  min-height: auto;
+}
+
 .zoneHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
   margin-bottom: 12px;
+}
+
+.zoneHeaderContent {
+  flex: 1;
+  min-width: 0;
 }
 
 .zoneTitle {
@@ -40,6 +53,27 @@
   margin: 4px 0 0;
   font-size: 13px;
   color: rgba(15, 23, 42, 0.55);
+}
+
+.toggleButton {
+  appearance: none;
+  border: none;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.08);
+  color: rgba(15, 23, 42, 0.75);
+  font-size: 12px;
+  font-weight: 600;
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+  white-space: nowrap;
+}
+
+.toggleButton:hover,
+.toggleButton:focus-visible {
+  background: rgba(59, 130, 246, 0.16);
+  color: rgba(37, 99, 235, 0.9);
+  outline: none;
 }
 
 .dropArea {

--- a/src/components/QuadrantBoard.tsx
+++ b/src/components/QuadrantBoard.tsx
@@ -19,9 +19,11 @@ const QUADRANT_DETAILS: Array<{
 
 interface QuadrantBoardProps {
   quadrants: Record<QuadrantId, Task[]>;
+  collapsed: Record<QuadrantId, boolean>;
   onDropTask: (taskId: string, quadrant: QuadrantId) => void;
   onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
   onResetTask: (taskId: string) => void;
+  onToggleCollapse: (quadrant: QuadrantId) => void;
 }
 
 function QuadrantZone({
@@ -29,19 +31,24 @@ function QuadrantZone({
   title,
   subtitle,
   tasks,
+  collapsed,
   onDrop,
   onUpdateTask,
   onResetTask,
+  onToggleCollapse,
 }: {
   quadrant: QuadrantId;
   title: string;
   subtitle: string;
   tasks: Task[];
+  collapsed: boolean;
   onDrop: (taskId: string, quadrant: QuadrantId) => void;
   onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
   onResetTask: (taskId: string) => void;
+  onToggleCollapse: (quadrant: QuadrantId) => void;
 }) {
   const [isDragOver, setIsDragOver] = useState(false);
+  const dropAreaId = `quadrant-${quadrant}`;
 
   const handleDragOver = (event: React.DragEvent<HTMLDivElement>) => {
     event.preventDefault();
@@ -62,31 +69,56 @@ function QuadrantZone({
     }
   };
 
+  const handleToggle = () => {
+    onToggleCollapse(quadrant);
+  };
+
   return (
-    <section className={styles.zone}>
+    <section className={`${styles.zone} ${collapsed ? styles.zoneCollapsed : ''}`.trim()}>
       <header className={styles.zoneHeader}>
-        <h3 className={styles.zoneTitle}>{title}</h3>
-        <p className={styles.zoneSubtitle}>{subtitle}</p>
+        <div className={styles.zoneHeaderContent}>
+          <h3 className={styles.zoneTitle}>{title}</h3>
+          <p className={styles.zoneSubtitle}>{subtitle}</p>
+        </div>
+        <button
+          type="button"
+          className={styles.toggleButton}
+          onClick={handleToggle}
+          aria-expanded={!collapsed}
+          aria-controls={dropAreaId}
+        >
+          {collapsed ? 'Развернуть' : 'Свернуть'}
+        </button>
       </header>
-      <div
-        className={`${styles.dropArea} ${isDragOver ? styles.dragOver : ''}`.trim()}
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
-      >
-        {tasks.length === 0 ? (
-          <div className={styles.emptyState}>Перетащите задачу сюда</div>
-        ) : (
-          tasks.map((task) => (
-            <TaskCard key={task.id} task={task} onUpdate={onUpdateTask} onReset={onResetTask} />
-          ))
-        )}
-      </div>
+      {!collapsed && (
+        <div
+          id={dropAreaId}
+          className={`${styles.dropArea} ${isDragOver ? styles.dragOver : ''}`.trim()}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {tasks.length === 0 ? (
+            <div className={styles.emptyState}>Перетащите задачу сюда</div>
+          ) : (
+            tasks.map((task) => (
+              <TaskCard key={task.id} task={task} onUpdate={onUpdateTask} onReset={onResetTask} />
+            ))
+          )}
+        </div>
+      )}
     </section>
   );
 }
 
-export function QuadrantBoard({ quadrants, onDropTask, onUpdateTask, onResetTask }: QuadrantBoardProps) {
+export function QuadrantBoard({
+  quadrants,
+  collapsed,
+  onDropTask,
+  onUpdateTask,
+  onResetTask,
+  onToggleCollapse,
+}: QuadrantBoardProps) {
   return (
     <div className={styles.board}>
       {QUADRANT_DETAILS.map(({ id, title, subtitle }) => (
@@ -96,9 +128,11 @@ export function QuadrantBoard({ quadrants, onDropTask, onUpdateTask, onResetTask
           title={title}
           subtitle={subtitle}
           tasks={quadrants[id] ?? []}
+          collapsed={collapsed[id as QuadrantId] ?? false}
           onDrop={onDropTask}
           onUpdateTask={onUpdateTask}
           onResetTask={onResetTask}
+          onToggleCollapse={onToggleCollapse}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- add collapse controls to the backlog panel and quadrant cards
- persist UI collapse preferences in localStorage so sections stay folded between reloads
- style new headers and buttons for the collapsible sections

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu due to npm optional dependency bug)*

------
https://chatgpt.com/codex/tasks/task_e_68cc67e7478c83329af85980f0aa06e7