### PR TITLE
Add theme toggle, pomodoro timer, and export enhancements

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -7,25 +7,39 @@
   margin: 0 auto;
 }
 
-.topRow {
-  display: flex;
-  flex-direction: column;
+.hero {
+  display: grid;
   gap: 20px;
 }
 
-@media (min-width: 960px) {
-  .topRow {
-    display: grid;
-    grid-template-columns: 1.1fr 1fr;
-    align-items: start;
-    gap: 28px;
-  }
+.actionRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  justify-content: flex-end;
 }
 
-.sideColumn {
+.actionRow > * {
+  flex-shrink: 0;
+}
+
+.topControls {
   display: flex;
-  flex-direction: column;
-  gap: 16px;
+  align-items: center;
+  gap: 12px;
+}
+
+.layoutGrid {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 1080px) {
+  .layoutGrid {
+    grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
+    align-items: start;
+  }
 }
 
 .boardRow {
@@ -50,4 +64,24 @@
   font-size: 12px;
   color: rgba(15, 23, 42, 0.55);
   margin: 0;
+}
+
+.focusOverlay {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: 24px;
+  border-radius: 28px;
+  background: var(--focus-overlay-bg);
+  box-shadow: var(--focus-overlay-shadow);
+}
+
+.focusOverlayTitle {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+  color: var(--focus-overlay-text);
 }

--- a/src/components/AddTaskButton.module.css
+++ b/src/components/AddTaskButton.module.css
@@ -1,0 +1,24 @@
+.button {
+  border: none;
+  background: var(--fab-bg);
+  color: var(--fab-fg);
+  padding: 10px;
+  border-radius: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--fab-shadow);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--fab-shadow-hover);
+}
+
+.icon {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+}

--- a/src/components/AddTaskButton.tsx
+++ b/src/components/AddTaskButton.tsx
@@ -1,0 +1,15 @@
+import styles from './AddTaskButton.module.css';
+
+interface AddTaskButtonProps {
+  onClick: () => void;
+}
+
+export function AddTaskButton({ onClick }: AddTaskButtonProps) {
+  return (
+    <button type="button" className={styles.button} onClick={onClick} aria-label="Добавить задачу">
+      <svg viewBox="0 0 24 24" className={styles.icon} aria-hidden>
+        <path d="M12 5a1 1 0 0 1 1 1v5h5a1 1 0 1 1 0 2h-5v5a1 1 0 1 1-2 0v-5H6a1 1 0 1 1 0-2h5V6a1 1 0 0 1 1-1Z" />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/BacklogList.module.css
+++ b/src/components/BacklogList.module.css
@@ -1,14 +1,20 @@
 .container {
-  background: rgba(255, 255, 255, 0.32);
+  background: var(--backlog-bg);
   border-radius: 22px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
+  border: 1px solid var(--backlog-border);
   padding: 18px;
-  box-shadow: 0 28px 56px -40px rgba(15, 23, 42, 0.45);
+  box-shadow: var(--backlog-shadow);
   display: flex;
   flex-direction: column;
   min-height: 320px;
   backdrop-filter: blur(28px) saturate(140%);
   -webkit-backdrop-filter: blur(28px) saturate(140%);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.container:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--backlog-shadow-hover);
 }
 
 .collapsed {
@@ -41,11 +47,11 @@
   font-size: 18px;
   font-weight: 700;
   margin: 0;
-  color: rgba(15, 23, 42, 0.9);
+  color: var(--backlog-title);
 }
 
 .count {
-  color: rgba(14, 116, 144, 0.9);
+  color: var(--backlog-count);
   font-size: 13px;
   display: block;
   margin-top: 4px;
@@ -56,7 +62,7 @@
   align-items: center;
   gap: 6px;
   font-size: 13px;
-  color: rgba(15, 23, 42, 0.65);
+  color: var(--backlog-checkbox-text);
   user-select: none;
   cursor: pointer;
 }
@@ -70,8 +76,8 @@
   appearance: none;
   border: none;
   border-radius: 9999px;
-  background: rgba(15, 23, 42, 0.08);
-  color: rgba(15, 23, 42, 0.75);
+  background: var(--backlog-toggle-bg);
+  color: var(--backlog-toggle-text);
   font-size: 12px;
   font-weight: 600;
   padding: 6px 12px;
@@ -82,8 +88,8 @@
 
 .toggleButton:hover,
 .toggleButton:focus-visible {
-  background: rgba(59, 130, 246, 0.16);
-  color: rgba(37, 99, 235, 0.9);
+  background: var(--backlog-toggle-bg-hover);
+  color: var(--backlog-toggle-text-hover);
   outline: none;
 }
 
@@ -92,19 +98,29 @@
   min-height: 220px;
   padding: 6px;
   border-radius: 16px;
-  border: 1px dashed rgba(255, 255, 255, 0.2);
+  border: 1px dashed var(--backlog-drop-border);
   transition: border-color 0.2s ease, background 0.2s ease;
-  background: rgba(255, 255, 255, 0.18);
+  background: var(--backlog-drop-bg);
   overflow: auto;
 }
 
 .dragOver {
-  border-color: rgba(59, 130, 246, 0.65);
-  background: rgba(59, 130, 246, 0.15);
+  border-color: var(--backlog-drop-border-active);
+  background: var(--backlog-drop-bg-active);
+  animation: pulse 0.6s ease infinite alternate;
+}
+
+@keyframes pulse {
+  from {
+    box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.15);
+  }
+  to {
+    box-shadow: 0 0 0 8px rgba(59, 130, 246, 0.05);
+  }
 }
 
 .empty {
-  color: rgba(15, 23, 42, 0.6);
+  color: var(--backlog-empty);
   font-size: 13px;
   text-align: center;
   margin-top: 24px;

--- a/src/components/BacklogList.tsx
+++ b/src/components/BacklogList.tsx
@@ -13,6 +13,17 @@ interface BacklogListProps {
   onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
   collapsed: boolean;
   onToggleCollapse: () => void;
+  pomodoroControls?: {
+    activeTaskId: string | null;
+    mode: 'focus' | 'short_break' | 'long_break' | 'idle';
+    runState: 'running' | 'paused' | 'stopped';
+    remainingSeconds: number;
+    stats: Record<string, number>;
+    onStart: (taskId: string) => void;
+    onPause: () => void;
+    onResume: () => void;
+    onReset: () => void;
+  };
 }
 
 export function BacklogList({
@@ -24,6 +35,7 @@ export function BacklogList({
   onUpdateTask,
   collapsed,
   onToggleCollapse,
+  pomodoroControls,
 }: BacklogListProps) {
   const [isDragOver, setIsDragOver] = useState(false);
   const displayedCount = totalCount ?? tasks.length;
@@ -93,7 +105,26 @@ export function BacklogList({
             </div>
           ) : (
             tasks.map((task) => (
-              <TaskCard key={task.id} task={task} onUpdate={onUpdateTask} />
+              <TaskCard
+                key={task.id}
+                task={task}
+                onUpdate={onUpdateTask}
+                pomodoro={
+                  pomodoroControls
+                    ? {
+                        activeTaskId: pomodoroControls.activeTaskId,
+                        mode: pomodoroControls.mode,
+                        runState: pomodoroControls.runState,
+                        remainingSeconds: pomodoroControls.remainingSeconds,
+                        completedCount: pomodoroControls.stats[task.id] ?? 0,
+                        onStart: pomodoroControls.onStart,
+                        onPause: pomodoroControls.onPause,
+                        onResume: pomodoroControls.onResume,
+                        onReset: pomodoroControls.onReset,
+                      }
+                    : undefined
+                }
+              />
             ))
           )}
         </div>

--- a/src/components/ImportPanel.tsx
+++ b/src/components/ImportPanel.tsx
@@ -5,13 +5,25 @@ interface ImportPanelProps {
   value: string;
   onChange: (value: string) => void;
   onImport: (jsonText: string, options: { resetQuadrants: boolean }) => Promise<void> | void;
-  onExport: () => void;
+  onExportJson: () => void;
+  onExportMarkdown: () => void;
+  onExportPdf: () => void;
   feedback?: string | null;
   error?: string | null;
   textareaRef?: React.RefObject<HTMLTextAreaElement>;
 }
 
-export function ImportPanel({ value, onChange, onImport, onExport, feedback, error, textareaRef }: ImportPanelProps) {
+export function ImportPanel({
+  value,
+  onChange,
+  onImport,
+  onExportJson,
+  onExportMarkdown,
+  onExportPdf,
+  feedback,
+  error,
+  textareaRef,
+}: ImportPanelProps) {
   const [resetQuadrants, setResetQuadrants] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
 
@@ -26,10 +38,6 @@ export function ImportPanel({ value, onChange, onImport, onExport, feedback, err
     } finally {
       setIsProcessing(false);
     }
-  };
-
-  const handleExport = () => {
-    onExport();
   };
 
   return (
@@ -57,15 +65,16 @@ export function ImportPanel({ value, onChange, onImport, onExport, feedback, err
           </label>
         </div>
         <div className={styles.buttons}>
-          <button className={styles.secondaryButton} type="button" onClick={handleExport}>
+          <button className={styles.secondaryButton} type="button" onClick={onExportJson}>
             Экспорт JSON
           </button>
-          <button
-            className={styles.primaryButton}
-            type="button"
-            onClick={handleImport}
-            disabled={isProcessing}
-          >
+          <button className={styles.secondaryButton} type="button" onClick={onExportMarkdown}>
+            Markdown
+          </button>
+          <button className={styles.secondaryButton} type="button" onClick={onExportPdf}>
+            PDF
+          </button>
+          <button className={styles.primaryButton} type="button" onClick={handleImport} disabled={isProcessing}>
             {isProcessing ? 'Импорт...' : 'Импорт'}
           </button>
         </div>

--- a/src/components/ManualTaskForm.tsx
+++ b/src/components/ManualTaskForm.tsx
@@ -144,7 +144,7 @@ export const ManualTaskForm = forwardRef<HTMLFormElement, ManualTaskFormProps>(
         <label className={styles.label}>
           Квадрант
           <select
-            className={`${styles.input} ${styles.select}`.trim()
+            className={`${styles.input} ${styles.select}`}
             value={quadrant}
             onChange={(event) => setQuadrant(event.target.value as Quadrant)}
           >

--- a/src/components/Modal.module.css
+++ b/src/components/Modal.module.css
@@ -1,0 +1,71 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 40;
+}
+
+.container {
+  width: min(560px, 100%);
+  background: var(--modal-bg);
+  color: var(--modal-text);
+  border-radius: 24px;
+  box-shadow: var(--modal-shadow);
+  border: 1px solid var(--modal-border);
+  overflow: hidden;
+  animation: fade-in 0.25s ease;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 24px 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+}
+
+.closeButton {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 999px;
+  color: var(--toolbar-icon-color);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.closeButton:hover {
+  background: var(--toolbar-hover-bg);
+  color: var(--toolbar-icon-color-hover);
+}
+
+.closeIcon {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.content {
+  padding: 12px 24px 24px;
+}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,47 @@
+import { ReactNode, useEffect } from 'react';
+import styles from './Modal.module.css';
+
+interface ModalProps {
+  open: boolean;
+  title?: string;
+  children: ReactNode;
+  onClose: () => void;
+}
+
+export function Modal({ open, title, children, onClose }: ModalProps) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <div className={styles.backdrop} role="dialog" aria-modal="true" aria-label={title}>
+      <div className={styles.container}>
+        <header className={styles.header}>
+          {title ? <h2 className={styles.title}>{title}</h2> : null}
+          <button type="button" className={styles.closeButton} onClick={onClose} aria-label="Закрыть окно">
+            <svg viewBox="0 0 24 24" className={styles.closeIcon}>
+              <path d="m18.3 5.71-1.41-1.42L12 9.17 7.11 4.29 5.7 5.7 10.59 10.6 5.7 15.49l1.41 1.41L12 12l4.89 4.9 1.41-1.41-4.88-4.9 4.88-4.88Z" />
+            </svg>
+          </button>
+        </header>
+        <div className={styles.content}>{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PomodoroBar.module.css
+++ b/src/components/PomodoroBar.module.css
@@ -1,0 +1,222 @@
+.bar {
+  padding: 18px 20px;
+  border-radius: 24px;
+  background: var(--pomodoro-bg);
+  color: var(--pomodoro-text);
+  box-shadow: var(--pomodoro-shadow);
+  border: 1px solid var(--pomodoro-border);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+@media (min-width: 960px) {
+  .main {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.timerInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.modeBadge {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: white;
+}
+
+.modeFocus {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+}
+
+.modeShort {
+  background: linear-gradient(135deg, #0ea5e9, #2563eb);
+}
+
+.modeLong {
+  background: linear-gradient(135deg, #a855f7, #7c3aed);
+}
+
+.modeIdle {
+  background: linear-gradient(135deg, #94a3b8, #64748b);
+}
+
+.time {
+  font-size: clamp(32px, 6vw, 48px);
+  font-weight: 700;
+}
+
+.progressWrapper {
+  display: grid;
+  gap: 6px;
+}
+
+.progressTrack {
+  height: 6px;
+  border-radius: 999px;
+  background: var(--pomodoro-track-bg);
+  overflow: hidden;
+}
+
+.progressFill {
+  height: 100%;
+  border-radius: inherit;
+  background: var(--pomodoro-track-fill);
+  transition: width 0.4s ease;
+}
+
+.taskName {
+  font-size: 14px;
+  color: var(--pomodoro-task-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.controlButton {
+  border: none;
+  background: var(--pomodoro-button-bg);
+  color: var(--pomodoro-button-text);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: var(--pomodoro-button-shadow);
+}
+
+.controlButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.controlButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--pomodoro-button-shadow-hover);
+}
+
+.controlActive {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(59, 130, 246, 0.7));
+  color: white;
+}
+
+.settingsToggle {
+  border: none;
+  background: none;
+  color: var(--pomodoro-task-color);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 999px;
+}
+
+.settingsToggle:hover {
+  background: var(--pomodoro-button-bg);
+}
+
+.bottomRow {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.statBox {
+  flex: 1 1 100px;
+  padding: 10px 14px;
+  border-radius: 16px;
+  background: var(--pomodoro-stat-bg);
+  display: grid;
+  gap: 4px;
+  text-align: center;
+}
+
+.statLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--pomodoro-task-color);
+}
+
+.statValue {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.settingsPanel {
+  border-top: 1px solid var(--pomodoro-border);
+  padding-top: 12px;
+  display: grid;
+  gap: 12px;
+}
+
+.settingsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.settingsField {
+  display: grid;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--pomodoro-task-color);
+}
+
+.settingsField input {
+  border: 1px solid var(--pomodoro-border);
+  border-radius: 10px;
+  padding: 6px 10px;
+  background: var(--pomodoro-input-bg);
+  color: inherit;
+}
+
+.settingsToggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--pomodoro-task-color);
+}
+
+.clearStats {
+  border: none;
+  background: none;
+  color: var(--pomodoro-button-text);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 10px;
+}
+
+.clearStats:hover {
+  background: var(--pomodoro-button-bg);
+}

--- a/src/components/PomodoroBar.tsx
+++ b/src/components/PomodoroBar.tsx
@@ -1,0 +1,234 @@
+import { useMemo, useState } from 'react';
+import { PomodoroConfig, PomodoroStats } from '../hooks/usePomodoroTimer';
+import { Task } from '../types';
+import styles from './PomodoroBar.module.css';
+
+type PomodoroMode = 'focus' | 'short_break' | 'long_break' | 'idle';
+type RunState = 'running' | 'paused' | 'stopped';
+
+interface PomodoroBarProps {
+  activeTask: Task | null;
+  mode: PomodoroMode;
+  runState: RunState;
+  remainingSeconds: number;
+  config: PomodoroConfig;
+  stats: PomodoroStats;
+  focusModeEnabled: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onReset: () => void;
+  onSkip: () => void;
+  onToggleFocusMode: () => void;
+  onUpdateConfig: (partial: Partial<PomodoroConfig>) => void;
+  onClearStats: () => void;
+}
+
+function formatTime(totalSeconds: number) {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+}
+
+function getModeMeta(mode: PomodoroMode) {
+  switch (mode) {
+    case 'focus':
+      return { label: 'Работа', className: styles.modeFocus };
+    case 'short_break':
+      return { label: 'Короткий отдых', className: styles.modeShort };
+    case 'long_break':
+      return { label: 'Длинный отдых', className: styles.modeLong };
+    default:
+      return { label: 'Не запущен', className: styles.modeIdle };
+  }
+}
+
+function useStats(stats: PomodoroStats) {
+  return useMemo(() => {
+    const now = new Date();
+    const weekStart = new Date(now);
+    weekStart.setDate(now.getDate() - now.getDay());
+    weekStart.setHours(0, 0, 0, 0);
+
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+
+    let weekly = 0;
+    let monthly = 0;
+
+    for (const iso of stats.history) {
+      const timestamp = new Date(iso);
+      if (Number.isNaN(timestamp.getTime())) {
+        continue;
+      }
+      if (timestamp >= weekStart) {
+        weekly += 1;
+      }
+      if (timestamp >= monthStart) {
+        monthly += 1;
+      }
+    }
+
+    return { weekly, monthly };
+  }, [stats.history]);
+}
+
+export function PomodoroBar({
+  activeTask,
+  mode,
+  runState,
+  remainingSeconds,
+  config,
+  stats,
+  focusModeEnabled,
+  onPause,
+  onResume,
+  onReset,
+  onSkip,
+  onToggleFocusMode,
+  onUpdateConfig,
+  onClearStats,
+}: PomodoroBarProps) {
+  const [showSettings, setShowSettings] = useState(false);
+  const modeMeta = getModeMeta(mode);
+  const progressBase =
+    mode === 'focus'
+      ? config.focusMinutes * 60
+      : mode === 'short_break'
+      ? config.shortBreakMinutes * 60
+      : mode === 'long_break'
+      ? config.longBreakMinutes * 60
+      : config.focusMinutes * 60;
+  const progress = progressBase ? 1 - remainingSeconds / progressBase : 0;
+  const statsSummary = useStats(stats);
+  const totalPomodoros = Object.values(stats.completedPerTask).reduce((acc, value) => acc + value, 0);
+
+  return (
+    <section className={styles.bar}>
+      <div className={styles.main}>
+        <div className={styles.timerInfo}>
+          <div className={`${styles.modeBadge} ${modeMeta.className}`.trim()}>{modeMeta.label}</div>
+          <div className={styles.time}>{formatTime(remainingSeconds)}</div>
+          <div className={styles.progressWrapper}>
+            <div className={styles.progressTrack}>
+              <div className={styles.progressFill} style={{ width: `${Math.min(100, Math.max(0, progress * 100))}%` }} />
+            </div>
+            <div className={styles.taskName}>{activeTask ? activeTask.title : 'Задача не выбрана'}</div>
+          </div>
+        </div>
+        <div className={styles.controls}>
+          {runState === 'running' ? (
+            <button type="button" className={styles.controlButton} onClick={onPause}>
+              Пауза (P)
+            </button>
+          ) : (
+            <button type="button" className={styles.controlButton} onClick={onResume} disabled={!activeTask}>
+              Старт (P)
+            </button>
+          )}
+          <button type="button" className={styles.controlButton} onClick={onSkip} disabled={mode === 'idle'}>
+            Следующий
+          </button>
+          <button type="button" className={styles.controlButton} onClick={onReset}>
+            Сброс (R)
+          </button>
+          <button
+            type="button"
+            className={`${styles.controlButton} ${focusModeEnabled ? styles.controlActive : ''}`.trim()}
+            onClick={onToggleFocusMode}
+          >
+            Фокус-режим
+          </button>
+          <button type="button" className={styles.settingsToggle} onClick={() => setShowSettings((value) => !value)}>
+            Настройки
+          </button>
+        </div>
+      </div>
+      <div className={styles.bottomRow}>
+        <div className={styles.statBox}>
+          <span className={styles.statLabel}>В неделю</span>
+          <span className={styles.statValue}>{statsSummary.weekly}</span>
+        </div>
+        <div className={styles.statBox}>
+          <span className={styles.statLabel}>В месяц</span>
+          <span className={styles.statValue}>{statsSummary.monthly}</span>
+        </div>
+        <div className={styles.statBox}>
+          <span className={styles.statLabel}>Всего</span>
+          <span className={styles.statValue}>{totalPomodoros}</span>
+        </div>
+      </div>
+      {showSettings ? (
+        <div className={styles.settingsPanel}>
+          <div className={styles.settingsGrid}>
+            <label className={styles.settingsField}>
+              Работа (мин)
+              <input
+                type="number"
+                min={1}
+                max={180}
+                value={config.focusMinutes}
+                onChange={(event) => onUpdateConfig({ focusMinutes: Number(event.target.value) || config.focusMinutes })}
+              />
+            </label>
+            <label className={styles.settingsField}>
+              Короткий отдых (мин)
+              <input
+                type="number"
+                min={1}
+                max={60}
+                value={config.shortBreakMinutes}
+                onChange={(event) =>
+                  onUpdateConfig({ shortBreakMinutes: Number(event.target.value) || config.shortBreakMinutes })
+                }
+              />
+            </label>
+            <label className={styles.settingsField}>
+              Длинный отдых (мин)
+              <input
+                type="number"
+                min={1}
+                max={120}
+                value={config.longBreakMinutes}
+                onChange={(event) =>
+                  onUpdateConfig({ longBreakMinutes: Number(event.target.value) || config.longBreakMinutes })
+                }
+              />
+            </label>
+            <label className={styles.settingsField}>
+              Через сколько циклов длинный отдых
+              <input
+                type="number"
+                min={1}
+                max={8}
+                value={config.longBreakEvery}
+                onChange={(event) =>
+                  onUpdateConfig({ longBreakEvery: Number(event.target.value) || config.longBreakEvery })
+                }
+              />
+            </label>
+          </div>
+          <div className={styles.settingsToggles}>
+            <label className={styles.toggle}>
+              <input
+                type="checkbox"
+                checked={config.autoTransition}
+                onChange={(event) => onUpdateConfig({ autoTransition: event.target.checked })}
+              />
+              Автоматический переход между режимами
+            </label>
+            <label className={styles.toggle}>
+              <input
+                type="checkbox"
+                checked={config.enableLongBreak}
+                onChange={(event) => onUpdateConfig({ enableLongBreak: event.target.checked })}
+              />
+              Длинный отдых после цикла
+            </label>
+            <button type="button" className={styles.clearStats} onClick={onClearStats}>
+              Сбросить статистику
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/PriorityOverview.module.css
+++ b/src/components/PriorityOverview.module.css
@@ -1,0 +1,69 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 16px;
+  width: 100%;
+}
+
+.card {
+  position: relative;
+  border: none;
+  border-radius: 20px;
+  padding: 18px 20px;
+  background: var(--priority-card-bg);
+  color: var(--priority-card-text);
+  box-shadow: var(--priority-card-shadow);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  overflow: hidden;
+}
+
+.card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, var(--accent-color) 0%, transparent 60%);
+  opacity: 0.16;
+  transition: opacity 0.25s ease;
+}
+
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--priority-card-shadow-hover);
+}
+
+.card:hover::after {
+  opacity: 0.28;
+}
+
+.quadrant {
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.title {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.counter {
+  margin-top: auto;
+  font-size: 26px;
+  font-weight: 700;
+  color: var(--priority-card-counter);
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+
+.counterTotal {
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--priority-card-counter-muted);
+}

--- a/src/components/PriorityOverview.tsx
+++ b/src/components/PriorityOverview.tsx
@@ -1,0 +1,56 @@
+import { CSSProperties } from 'react';
+import { Quadrant, Task } from '../types';
+import styles from './PriorityOverview.module.css';
+
+interface PriorityOverviewProps {
+  quadrants: Record<Quadrant, Task[]>;
+  onSelect?: (quadrant: Quadrant) => void;
+}
+
+const TITLES: Record<Exclude<Quadrant, 'backlog'>, string> = {
+  Q1: 'Срочно + Важно',
+  Q2: 'Несрочно + Важно',
+  Q3: 'Срочно + Неважно',
+  Q4: 'Несрочно + Неважно',
+};
+
+const COLORS: Record<Exclude<Quadrant, 'backlog'>, string> = {
+  Q1: '#ef4444',
+  Q2: '#22c55e',
+  Q3: '#f97316',
+  Q4: '#8b5cf6',
+};
+
+function getStats(tasks: Task[]) {
+  const total = tasks.length;
+  const active = tasks.filter((task) => !(task.done ?? false)).length;
+  return { total, active };
+}
+
+export function PriorityOverview({ quadrants, onSelect }: PriorityOverviewProps) {
+  return (
+    <div className={styles.grid}>
+      {(Object.keys(TITLES) as Array<Exclude<Quadrant, 'backlog'>>).map((quadrant) => {
+        const stats = getStats(quadrants[quadrant] ?? []);
+        return (
+          <button
+            key={quadrant}
+            type="button"
+            className={styles.card}
+            style={
+              { '--accent-color': COLORS[quadrant] } as CSSProperties
+            }
+            onClick={() => onSelect?.(quadrant)}
+          >
+            <span className={styles.quadrant}>{quadrant}</span>
+            <span className={styles.title}>{TITLES[quadrant]}</span>
+            <span className={styles.counter}>
+              {stats.active}
+              <span className={styles.counterTotal}>/{stats.total}</span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/QuadrantBoard.module.css
+++ b/src/components/QuadrantBoard.module.css
@@ -13,16 +13,22 @@
 }
 
 .zone {
-  background: rgba(255, 255, 255, 0.28);
+  background: var(--quadrant-bg);
   border-radius: 24px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
+  border: 1px solid var(--quadrant-border);
   padding: 18px;
-  box-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.5);
+  box-shadow: var(--quadrant-shadow);
   display: flex;
   flex-direction: column;
   backdrop-filter: blur(30px) saturate(140%);
   -webkit-backdrop-filter: blur(30px) saturate(140%);
   position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.zone:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--quadrant-shadow-hover);
 }
 
 .zoneCollapsed {
@@ -30,15 +36,20 @@
 }
 
 .zoneHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 8px;
   margin-bottom: 12px;
 }
 
+@media (min-width: 720px) {
+  .zoneHeader {
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+  }
+}
+
 .zoneHeaderContent {
-  flex: 1;
   min-width: 0;
 }
 
@@ -46,21 +57,33 @@
   margin: 0;
   font-size: 17px;
   font-weight: 700;
-  color: rgba(15, 23, 42, 0.9);
+  color: var(--quadrant-title);
 }
 
 .zoneSubtitle {
   margin: 4px 0 0;
   font-size: 13px;
-  color: rgba(15, 23, 42, 0.55);
+  color: var(--quadrant-subtitle);
+}
+
+.zoneStats {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  font-size: 12px;
+  color: var(--quadrant-stats);
+}
+
+.zoneStatsItem strong {
+  color: var(--quadrant-stats-strong);
 }
 
 .toggleButton {
   appearance: none;
   border: none;
   border-radius: 9999px;
-  background: rgba(15, 23, 42, 0.08);
-  color: rgba(15, 23, 42, 0.75);
+  background: var(--quadrant-toggle-bg);
+  color: var(--quadrant-toggle-text);
   font-size: 12px;
   font-weight: 600;
   padding: 6px 12px;
@@ -71,29 +94,39 @@
 
 .toggleButton:hover,
 .toggleButton:focus-visible {
-  background: rgba(59, 130, 246, 0.16);
-  color: rgba(37, 99, 235, 0.9);
+  background: var(--quadrant-toggle-bg-hover);
+  color: var(--quadrant-toggle-text-hover);
   outline: none;
 }
 
 .dropArea {
   flex: 1;
   border-radius: 18px;
-  border: 1px dashed rgba(255, 255, 255, 0.24);
+  border: 1px dashed var(--quadrant-drop-border);
   padding: 8px;
   transition: border-color 0.2s ease, background 0.2s ease;
-  background: rgba(255, 255, 255, 0.16);
+  background: var(--quadrant-drop-bg);
   overflow: auto;
   max-height: var(--quadrant-max-height, none);
 }
 
 .dragOver {
-  border-color: rgba(56, 189, 248, 0.8);
-  background: rgba(56, 189, 248, 0.18);
+  border-color: var(--quadrant-drop-border-active);
+  background: var(--quadrant-drop-bg-active);
+  animation: pulse 0.6s ease infinite alternate;
+}
+
+@keyframes pulse {
+  from {
+    box-shadow: 0 0 0 0 rgba(56, 189, 248, 0.15);
+  }
+  to {
+    box-shadow: 0 0 0 8px rgba(56, 189, 248, 0.05);
+  }
 }
 
 .emptyState {
-  color: rgba(15, 23, 42, 0.6);
+  color: var(--quadrant-empty);
   font-size: 13px;
   text-align: center;
   margin-top: 24px;

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -1,37 +1,84 @@
 .wrapper {
-  display: flex;
-  gap: 12px;
+  display: inline-flex;
   align-items: center;
-  background: rgba(255, 255, 255, 0.28);
-  border-radius: 18px;
-  padding: 14px 18px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  box-shadow: 0 20px 40px -32px rgba(15, 23, 42, 0.45);
-  backdrop-filter: blur(26px) saturate(140%);
-  -webkit-backdrop-filter: blur(26px) saturate(140%);
+  gap: 10px;
+  background: var(--toolbar-bg);
+  border-radius: 999px;
+  padding: 6px;
+  border: 1px solid var(--toolbar-border);
+  box-shadow: var(--toolbar-shadow);
+  transition: width 0.3s ease, background 0.3s ease;
+  width: auto;
+}
+
+.iconButton {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--toolbar-icon-color);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.iconButton:hover {
+  background: var(--toolbar-hover-bg);
+  color: var(--toolbar-icon-color-hover);
+  transform: translateY(-1px);
+}
+
+.icon {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.inputContainer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 6px;
+  max-width: 0;
+  opacity: 0;
+  transition: max-width 0.3s ease, opacity 0.2s ease;
+}
+
+.expanded .inputContainer {
+  max-width: 360px;
+  opacity: 1;
 }
 
 .searchInput {
-  flex: 1;
   border: none;
   outline: none;
   font-size: 14px;
-  color: #0f172a;
-  background: transparent;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--toolbar-input-bg);
+  color: var(--toolbar-input-color);
+  box-shadow: inset 0 0 0 1px var(--toolbar-input-border);
+  transition: box-shadow 0.2s ease;
+}
+
+.searchInput:focus {
+  box-shadow: inset 0 0 0 2px var(--toolbar-focus-border);
 }
 
 .clearButton {
-  background: rgba(37, 99, 235, 0.1);
+  background: none;
   border: none;
-  color: rgba(37, 99, 235, 0.9);
+  color: var(--toolbar-icon-color);
   cursor: pointer;
   font-weight: 600;
-  padding: 8px 16px;
+  padding: 8px 12px;
   border-radius: 999px;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
 .clearButton:hover {
-  background: rgba(37, 99, 235, 0.18);
-  color: rgba(37, 99, 235, 1);
+  background: var(--toolbar-hover-bg);
+  color: var(--toolbar-icon-color-hover);
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,26 +1,58 @@
+import { useEffect } from 'react';
 import styles from './SearchBar.module.css';
 
 interface SearchBarProps {
   value: string;
+  expanded: boolean;
   onChange: (value: string) => void;
   onClear: () => void;
+  onToggle: (next: boolean) => void;
   inputRef?: React.RefObject<HTMLInputElement>;
 }
 
-export function SearchBar({ value, onChange, onClear, inputRef }: SearchBarProps) {
+export function SearchBar({ value, expanded, onChange, onClear, onToggle, inputRef }: SearchBarProps) {
+  useEffect(() => {
+    if (expanded) {
+      window.requestAnimationFrame(() => {
+        inputRef?.current?.focus();
+        inputRef?.current?.select();
+      });
+    }
+  }, [expanded, inputRef]);
+
+  const handleClear = () => {
+    onClear();
+    if (!value) {
+      onToggle(false);
+    }
+  };
+
   return (
-    <div className={styles.wrapper}>
-      <input
-        ref={inputRef}
-        className={styles.searchInput}
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        placeholder="Поиск по бэклогу"
-        type="search"
-      />
-      <button type="button" className={styles.clearButton} onClick={onClear}>
-        Очистить
+    <div className={`${styles.wrapper} ${expanded ? styles.expanded : ''}`.trim()}>
+      <button
+        type="button"
+        className={styles.iconButton}
+        aria-label="Поиск"
+        onClick={() => onToggle(!expanded)}
+      >
+        <svg viewBox="0 0 24 24" className={styles.icon} aria-hidden>
+          <path d="M21 21a1 1 0 0 1-1.71.71l-4.92-4.93a7 7 0 1 1 1.41-1.41l4.93 4.92A1 1 0 0 1 21 21Zm-10-4a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z" />
+        </svg>
       </button>
+      <div className={styles.inputContainer}>
+        <input
+          ref={inputRef}
+          className={styles.searchInput}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder="Поиск по бэклогу"
+          type="search"
+          aria-hidden={!expanded}
+        />
+        <button type="button" className={styles.clearButton} onClick={handleClear}>
+          Очистить
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/TaskCard.module.css
+++ b/src/components/TaskCard.module.css
@@ -1,10 +1,10 @@
 .card {
-  background: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.65);
+  background: var(--task-card-bg);
+  border: 1px solid var(--task-card-border);
   border-radius: 18px;
   padding: 14px 16px;
   margin-bottom: 12px;
-  box-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.55);
+  box-shadow: var(--task-card-shadow);
   cursor: grab;
   transition: box-shadow 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
   outline: none;
@@ -69,7 +69,7 @@
   padding: 0;
   font-size: 15px;
   font-weight: 600;
-  color: rgba(15, 23, 42, 0.92);
+  color: var(--task-card-title);
   text-align: left;
   cursor: text;
   word-break: break-word;
@@ -80,14 +80,14 @@
 }
 
 .titleDone {
-  color: rgba(15, 23, 42, 0.55);
+  color: var(--task-card-title-done);
   text-decoration: line-through;
 }
 
 .backlogButton {
-  background: rgba(37, 99, 235, 0.1);
+  background: var(--task-card-backlog-bg);
   border: none;
-  color: rgba(37, 99, 235, 0.95);
+  color: var(--task-card-backlog-text);
   font-size: 13px;
   padding: 6px 10px;
   border-radius: 999px;
@@ -97,8 +97,8 @@
 }
 
 .backlogButton:hover {
-  background: rgba(37, 99, 235, 0.2);
-  color: rgba(37, 99, 235, 1);
+  background: var(--task-card-backlog-bg-hover);
+  color: var(--task-card-backlog-text-hover);
 }
 
 .dueRow {
@@ -106,9 +106,9 @@
 }
 
 .dueButton {
-  background: rgba(255, 255, 255, 0.5);
-  border: 1px solid rgba(255, 255, 255, 0.6);
-  color: rgba(15, 23, 42, 0.65);
+  background: var(--task-card-due-bg);
+  border: 1px solid var(--task-card-due-border);
+  color: var(--task-card-due-text);
   font-size: 13px;
   padding: 6px 10px;
   border-radius: 999px;
@@ -130,11 +130,11 @@
 
 .input {
   padding: 8px 10px;
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  border: 1px solid var(--task-card-input-border);
   border-radius: 10px;
   font-size: 13px;
-  background: rgba(255, 255, 255, 0.72);
-  color: #0f172a;
+  background: var(--task-card-input-bg);
+  color: var(--task-card-input-text);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -155,4 +155,94 @@
 
 .cardDone .dueButton {
   color: rgba(148, 163, 184, 0.85);
+}
+
+.pomodoro {
+  margin-top: 14px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pomodoroActive {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 24px -18px rgba(15, 23, 42, 0.35);
+}
+
+.pomodoroInfo {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.pomodoroLabel {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: white;
+}
+
+.pomodoroCount {
+  font-size: 18px;
+  font-weight: 700;
+  color: white;
+}
+
+.pomodoroTime {
+  font-size: 16px;
+  font-weight: 600;
+  color: white;
+}
+
+.pomodoroActions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pomodoroButton,
+.pomodoroButtonSecondary {
+  border: none;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.pomodoroButton {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
+.pomodoroButtonSecondary {
+  background: rgba(15, 23, 42, 0.18);
+  color: white;
+}
+
+.pomodoroButton:hover,
+.pomodoroButtonSecondary:hover {
+  transform: translateY(-1px);
+}
+
+.pomodoroFocus {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.85), rgba(22, 163, 74, 0.8));
+}
+
+.pomodoroShort {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.85), rgba(37, 99, 235, 0.8));
+}
+
+.pomodoroLong {
+  background: linear-gradient(135deg, rgba(168, 85, 247, 0.85), rgba(124, 58, 237, 0.8));
+}
+
+.pomodoroIdle {
+  background: linear-gradient(135deg, rgba(148, 163, 184, 0.65), rgba(100, 116, 139, 0.6));
 }

--- a/src/components/ThemeToggleButton.module.css
+++ b/src/components/ThemeToggleButton.module.css
@@ -1,0 +1,24 @@
+.button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--toolbar-icon-color);
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.button:hover {
+  background: var(--toolbar-hover-bg);
+  color: var(--toolbar-icon-color-hover);
+  transform: translateY(-1px);
+}
+
+.icon {
+  width: 22px;
+  height: 22px;
+  fill: currentColor;
+}

--- a/src/components/ThemeToggleButton.tsx
+++ b/src/components/ThemeToggleButton.tsx
@@ -1,0 +1,29 @@
+import styles from './ThemeToggleButton.module.css';
+
+interface ThemeToggleButtonProps {
+  theme: 'light' | 'dark';
+  onToggle: () => void;
+}
+
+export function ThemeToggleButton({ theme, onToggle }: ThemeToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      className={styles.button}
+      onClick={onToggle}
+      aria-label={theme === 'light' ? 'Включить тёмную тему' : 'Включить светлую тему'}
+    >
+      <span aria-hidden>
+        {theme === 'light' ? (
+          <svg viewBox="0 0 24 24" className={styles.icon}>
+            <path d="M12 18a6 6 0 1 0 0-12 6 6 0 0 0 0 12Zm0 4a1 1 0 0 1-1-1v-1a1 1 0 1 1 2 0v1a1 1 0 0 1-1 1Zm0-20a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1Zm10 9a1 1 0 0 1 0 2h-1a1 1 0 1 1 0-2h1Zm-18 0a1 1 0 0 1 0 2H3a1 1 0 1 1 0-2h1Zm15.07 7.07a1 1 0 0 1-1.41 1.41l-.71-.7a1 1 0 0 1 1.41-1.42l.71.71Zm-12-12a1 1 0 0 1-1.41 1.41l-.71-.7a1 1 0 0 1 1.41-1.42l.71.71Zm-1.42 12a1 1 0 0 1 1.42-1.41l.7.71a1 1 0 1 1-1.41 1.41l-.71-.71Zm12-12a1 1 0 1 1 1.41-1.41l.71.7a1 1 0 1 1-1.42 1.42l-.7-.71Z" />
+          </svg>
+        ) : (
+          <svg viewBox="0 0 24 24" className={styles.icon}>
+            <path d="M21.64 13.65A1 1 0 0 0 20.6 13a8 8 0 0 1-9.6-9.6 1 1 0 0 0-1.18-1.18 10 10 0 1 0 11.83 11.83 1 1 0 0 0-.01-.4Z" />
+          </svg>
+        )}
+      </span>
+    </button>
+  );
+}

--- a/src/hooks/usePomodoroTimer.ts
+++ b/src/hooks/usePomodoroTimer.ts
@@ -1,0 +1,300 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+type PomodoroMode = 'focus' | 'short_break' | 'long_break' | 'idle';
+type RunState = 'running' | 'paused' | 'stopped';
+
+export interface PomodoroConfig {
+  focusMinutes: number;
+  shortBreakMinutes: number;
+  longBreakMinutes: number;
+  longBreakEvery: number;
+  autoTransition: boolean;
+  enableLongBreak: boolean;
+}
+
+export interface PomodoroStats {
+  completedPerTask: Record<string, number>;
+  history: string[];
+}
+
+interface PomodoroState {
+  activeTaskId: string | null;
+  mode: PomodoroMode;
+  runState: RunState;
+  remainingSeconds: number;
+  streak: number;
+  config: PomodoroConfig;
+  stats: PomodoroStats;
+}
+
+const DEFAULT_CONFIG: PomodoroConfig = {
+  focusMinutes: 25,
+  shortBreakMinutes: 5,
+  longBreakMinutes: 15,
+  longBreakEvery: 4,
+  autoTransition: true,
+  enableLongBreak: true,
+};
+
+const STORAGE_KEY = 'eisenhower-pomodoro-state-v1';
+
+function loadState(): PomodoroState {
+  if (typeof window === 'undefined') {
+    return {
+      activeTaskId: null,
+      mode: 'idle',
+      runState: 'stopped',
+      remainingSeconds: DEFAULT_CONFIG.focusMinutes * 60,
+      streak: 0,
+      config: DEFAULT_CONFIG,
+      stats: { completedPerTask: {}, history: [] },
+    };
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) throw new Error('No state');
+    const parsed = JSON.parse(raw) as Partial<PomodoroState>;
+    return {
+      activeTaskId: parsed.activeTaskId ?? null,
+      mode: parsed.mode === 'focus' || parsed.mode === 'short_break' || parsed.mode === 'long_break' ? parsed.mode : 'idle',
+      runState: parsed.runState === 'running' || parsed.runState === 'paused' ? parsed.runState : 'stopped',
+      remainingSeconds: typeof parsed.remainingSeconds === 'number' ? parsed.remainingSeconds : DEFAULT_CONFIG.focusMinutes * 60,
+      streak: typeof parsed.streak === 'number' ? parsed.streak : 0,
+      config: {
+        focusMinutes: parsed.config?.focusMinutes ?? DEFAULT_CONFIG.focusMinutes,
+        shortBreakMinutes: parsed.config?.shortBreakMinutes ?? DEFAULT_CONFIG.shortBreakMinutes,
+        longBreakMinutes: parsed.config?.longBreakMinutes ?? DEFAULT_CONFIG.longBreakMinutes,
+        longBreakEvery: parsed.config?.longBreakEvery ?? DEFAULT_CONFIG.longBreakEvery,
+        autoTransition: parsed.config?.autoTransition ?? DEFAULT_CONFIG.autoTransition,
+        enableLongBreak: parsed.config?.enableLongBreak ?? DEFAULT_CONFIG.enableLongBreak,
+      },
+      stats: {
+        completedPerTask: parsed.stats?.completedPerTask ?? {},
+        history: parsed.stats?.history ?? [],
+      },
+    };
+  } catch (error) {
+    console.warn('Failed to load pomodoro state', error);
+    return {
+      activeTaskId: null,
+      mode: 'idle',
+      runState: 'stopped',
+      remainingSeconds: DEFAULT_CONFIG.focusMinutes * 60,
+      streak: 0,
+      config: DEFAULT_CONFIG,
+      stats: { completedPerTask: {}, history: [] },
+    };
+  }
+}
+
+function getDurationSeconds(config: PomodoroConfig, mode: PomodoroMode): number {
+  if (mode === 'focus') return config.focusMinutes * 60;
+  if (mode === 'short_break') return config.shortBreakMinutes * 60;
+  if (mode === 'long_break') return config.longBreakMinutes * 60;
+  return config.focusMinutes * 60;
+}
+
+export function usePomodoroTimer() {
+  const [{ activeTaskId, mode, runState, remainingSeconds, streak, config, stats }, setState] = useState<PomodoroState>(() =>
+    loadState(),
+  );
+  const intervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const payload: PomodoroState = {
+      activeTaskId,
+      mode,
+      runState,
+      remainingSeconds,
+      streak,
+      config,
+      stats,
+    };
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  }, [activeTaskId, mode, runState, remainingSeconds, streak, config, stats]);
+
+  const clearIntervalRef = useCallback(() => {
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const scheduleTick = useCallback(() => {
+    clearIntervalRef();
+    intervalRef.current = window.setInterval(() => {
+      setState((prev) => {
+        if (prev.runState !== 'running') {
+          return prev;
+        }
+        const nextRemaining = Math.max(0, prev.remainingSeconds - 1);
+        if (nextRemaining > 0) {
+          return { ...prev, remainingSeconds: nextRemaining };
+        }
+
+        const nowIso = new Date().toISOString();
+        const nextStats: PomodoroStats = {
+          completedPerTask: { ...prev.stats.completedPerTask },
+          history: prev.stats.history.slice(-200),
+        };
+
+        if (prev.mode === 'focus' && prev.activeTaskId) {
+          nextStats.completedPerTask[prev.activeTaskId] = (nextStats.completedPerTask[prev.activeTaskId] ?? 0) + 1;
+          nextStats.history = [...nextStats.history, nowIso];
+        }
+
+        const isFocus = prev.mode === 'focus';
+        const nextStreak = isFocus ? prev.streak + 1 : prev.streak;
+        const shouldLongBreak =
+          prev.config.enableLongBreak && isFocus && nextStreak % prev.config.longBreakEvery === 0;
+        const nextMode: PomodoroMode =
+          prev.mode === 'focus'
+            ? shouldLongBreak
+              ? 'long_break'
+              : 'short_break'
+            : prev.activeTaskId
+            ? 'focus'
+            : 'idle';
+
+        const nextRemainingSeconds = getDurationSeconds(prev.config, nextMode);
+        const shouldContinue = prev.config.autoTransition && nextMode !== 'idle';
+
+        if (!shouldContinue) {
+          clearIntervalRef();
+        }
+
+        if (nextMode === 'idle') {
+          return {
+            ...prev,
+            mode: 'idle',
+            runState: 'stopped',
+            remainingSeconds: getDurationSeconds(prev.config, 'focus'),
+            stats: nextStats,
+            streak: nextMode === 'idle' ? 0 : nextStreak,
+          };
+        }
+
+        return {
+          ...prev,
+          mode: nextMode,
+          runState: shouldContinue ? 'running' : 'paused',
+          remainingSeconds: nextRemainingSeconds,
+          stats: nextStats,
+          streak: nextMode === 'focus' ? nextStreak : prev.streak,
+        };
+      });
+    }, 1000);
+  }, [clearIntervalRef]);
+
+  useEffect(() => {
+    if (runState === 'running') {
+      scheduleTick();
+    } else {
+      clearIntervalRef();
+    }
+
+    return clearIntervalRef;
+  }, [runState, scheduleTick, clearIntervalRef]);
+
+  const start = useCallback(
+    (taskId: string) => {
+      setState((prev) => ({
+        ...prev,
+        activeTaskId: taskId,
+        mode: 'focus',
+        runState: 'running',
+        remainingSeconds: getDurationSeconds(prev.config, 'focus'),
+      }));
+    },
+    [],
+  );
+
+  const pause = useCallback(() => {
+    setState((prev) => ({ ...prev, runState: 'paused' }));
+  }, []);
+
+  const resume = useCallback(() => {
+    setState((prev) => ({ ...prev, runState: 'running' }));
+  }, []);
+
+  const reset = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      runState: 'stopped',
+      mode: 'idle',
+      remainingSeconds: getDurationSeconds(prev.config, 'focus'),
+      streak: 0,
+      activeTaskId: null,
+    }));
+  }, []);
+
+  const skip = useCallback(() => {
+    setState((prev) => {
+      if (prev.mode === 'idle') {
+        return prev;
+      }
+      const nextMode: PomodoroMode =
+        prev.mode === 'focus'
+          ? prev.config.enableLongBreak && (prev.streak + 1) % prev.config.longBreakEvery === 0
+            ? 'long_break'
+            : 'short_break'
+          : prev.activeTaskId
+          ? 'focus'
+          : 'idle';
+
+      return {
+        ...prev,
+        mode: nextMode,
+        runState: nextMode === 'idle' ? 'stopped' : prev.config.autoTransition ? 'running' : 'paused',
+        remainingSeconds: getDurationSeconds(prev.config, nextMode === 'idle' ? 'focus' : nextMode),
+      };
+    });
+  }, []);
+
+  const updateConfig = useCallback((partial: Partial<PomodoroConfig>) => {
+    setState((prev) => {
+      const nextConfig: PomodoroConfig = { ...prev.config, ...partial };
+      const nextRemaining = getDurationSeconds(nextConfig, prev.mode === 'idle' ? 'focus' : prev.mode);
+      return {
+        ...prev,
+        config: nextConfig,
+        remainingSeconds: prev.runState === 'stopped' ? nextRemaining : prev.remainingSeconds,
+      };
+    });
+  }, []);
+
+  const clearStats = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      stats: { completedPerTask: {}, history: [] },
+    }));
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      activeTaskId,
+      mode,
+      runState,
+      remainingSeconds,
+      streak,
+      config,
+      stats,
+      start,
+      pause,
+      resume,
+      reset,
+      skip,
+      updateConfig,
+      clearStats,
+    }),
+    [activeTaskId, mode, runState, remainingSeconds, streak, config, stats, start, pause, resume, reset, skip, updateConfig, clearStats],
+  );
+
+  return value;
+}

--- a/src/hooks/useThemePreference.ts
+++ b/src/hooks/useThemePreference.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'eisenhower-theme';
+
+function getPreferredTheme(): Theme {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    return 'dark';
+  }
+
+  return 'light';
+}
+
+export function useThemePreference() {
+  const [theme, setTheme] = useState<Theme>(() => getPreferredTheme());
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const root = document.documentElement;
+    root.dataset.theme = theme;
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handleChange = (event: MediaQueryListEvent) => {
+      setTheme(event.matches ? 'dark' : 'light');
+    };
+
+    mediaQuery.addEventListener('change', handleChange);
+    return () => mediaQuery.removeEventListener('change', handleChange);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((previous) => (previous === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  const value = useMemo(() => ({ theme, toggleTheme }), [theme, toggleTheme]);
+
+  return value;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,205 @@
 :root {
-  color-scheme: light;
+  color-scheme: light dark;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  color: #0f172a;
   background-color: #e4ecff;
+  color: #0f172a;
+
+  --toolbar-bg: rgba(255, 255, 255, 0.35);
+  --toolbar-border: rgba(255, 255, 255, 0.55);
+  --toolbar-shadow: 0 18px 40px -32px rgba(15, 23, 42, 0.45);
+  --toolbar-icon-color: rgba(15, 23, 42, 0.75);
+  --toolbar-icon-color-hover: rgba(37, 99, 235, 0.95);
+  --toolbar-hover-bg: rgba(37, 99, 235, 0.12);
+  --toolbar-input-bg: rgba(255, 255, 255, 0.7);
+  --toolbar-input-border: rgba(37, 99, 235, 0.2);
+  --toolbar-input-color: #0f172a;
+  --toolbar-focus-border: rgba(37, 99, 235, 0.45);
+
+  --priority-card-bg: rgba(255, 255, 255, 0.55);
+  --priority-card-text: rgba(15, 23, 42, 0.85);
+  --priority-card-shadow: 0 28px 48px -40px rgba(15, 23, 42, 0.45);
+  --priority-card-shadow-hover: 0 32px 60px -42px rgba(15, 23, 42, 0.55);
+  --priority-card-counter: rgba(15, 23, 42, 0.92);
+  --priority-card-counter-muted: rgba(15, 23, 42, 0.5);
+
+  --pomodoro-bg: rgba(255, 255, 255, 0.6);
+  --pomodoro-text: rgba(15, 23, 42, 0.9);
+  --pomodoro-shadow: 0 32px 64px -48px rgba(15, 23, 42, 0.5);
+  --pomodoro-border: rgba(255, 255, 255, 0.55);
+  --pomodoro-track-bg: rgba(15, 23, 42, 0.08);
+  --pomodoro-track-fill: linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(14, 165, 233, 0.85));
+  --pomodoro-task-color: rgba(15, 23, 42, 0.6);
+  --pomodoro-button-bg: rgba(59, 130, 246, 0.12);
+  --pomodoro-button-text: rgba(37, 99, 235, 0.95);
+  --pomodoro-button-shadow: 0 18px 32px -28px rgba(37, 99, 235, 0.35);
+  --pomodoro-button-shadow-hover: 0 20px 36px -28px rgba(37, 99, 235, 0.45);
+  --pomodoro-stat-bg: rgba(255, 255, 255, 0.55);
+  --pomodoro-input-bg: rgba(255, 255, 255, 0.68);
+
+  --fab-bg: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(14, 165, 233, 0.85));
+  --fab-fg: #ffffff;
+  --fab-shadow: 0 18px 40px -28px rgba(37, 99, 235, 0.7);
+  --fab-shadow-hover: 0 24px 48px -32px rgba(37, 99, 235, 0.85);
+
+  --task-card-bg: rgba(255, 255, 255, 0.7);
+  --task-card-border: rgba(255, 255, 255, 0.65);
+  --task-card-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.45);
+  --task-card-title: rgba(15, 23, 42, 0.92);
+  --task-card-title-done: rgba(15, 23, 42, 0.55);
+  --task-card-backlog-bg: rgba(37, 99, 235, 0.1);
+  --task-card-backlog-text: rgba(37, 99, 235, 0.95);
+  --task-card-backlog-bg-hover: rgba(37, 99, 235, 0.2);
+  --task-card-backlog-text-hover: rgba(37, 99, 235, 1);
+  --task-card-due-bg: rgba(255, 255, 255, 0.5);
+  --task-card-due-border: rgba(255, 255, 255, 0.6);
+  --task-card-due-text: rgba(15, 23, 42, 0.65);
+  --task-card-input-border: rgba(255, 255, 255, 0.6);
+  --task-card-input-bg: rgba(255, 255, 255, 0.72);
+  --task-card-input-text: #0f172a;
+
+  --quadrant-bg: rgba(255, 255, 255, 0.28);
+  --quadrant-border: rgba(255, 255, 255, 0.45);
+  --quadrant-shadow: 0 30px 60px -45px rgba(15, 23, 42, 0.45);
+  --quadrant-shadow-hover: 0 34px 64px -44px rgba(15, 23, 42, 0.55);
+  --quadrant-title: rgba(15, 23, 42, 0.9);
+  --quadrant-subtitle: rgba(15, 23, 42, 0.55);
+  --quadrant-stats: rgba(15, 23, 42, 0.6);
+  --quadrant-stats-strong: rgba(15, 23, 42, 0.85);
+  --quadrant-toggle-bg: rgba(15, 23, 42, 0.08);
+  --quadrant-toggle-text: rgba(15, 23, 42, 0.75);
+  --quadrant-toggle-bg-hover: rgba(59, 130, 246, 0.16);
+  --quadrant-toggle-text-hover: rgba(37, 99, 235, 0.9);
+  --quadrant-drop-border: rgba(255, 255, 255, 0.24);
+  --quadrant-drop-bg: rgba(255, 255, 255, 0.16);
+  --quadrant-drop-border-active: rgba(56, 189, 248, 0.8);
+  --quadrant-drop-bg-active: rgba(56, 189, 248, 0.18);
+  --quadrant-empty: rgba(15, 23, 42, 0.6);
+
+  --backlog-bg: rgba(255, 255, 255, 0.32);
+  --backlog-border: rgba(255, 255, 255, 0.45);
+  --backlog-shadow: 0 28px 56px -40px rgba(15, 23, 42, 0.45);
+  --backlog-shadow-hover: 0 32px 60px -42px rgba(15, 23, 42, 0.5);
+  --backlog-title: rgba(15, 23, 42, 0.9);
+  --backlog-count: rgba(14, 116, 144, 0.9);
+  --backlog-checkbox-text: rgba(15, 23, 42, 0.65);
+  --backlog-toggle-bg: rgba(15, 23, 42, 0.08);
+  --backlog-toggle-text: rgba(15, 23, 42, 0.75);
+  --backlog-toggle-bg-hover: rgba(59, 130, 246, 0.16);
+  --backlog-toggle-text-hover: rgba(37, 99, 235, 0.9);
+  --backlog-drop-border: rgba(255, 255, 255, 0.2);
+  --backlog-drop-bg: rgba(255, 255, 255, 0.18);
+  --backlog-drop-border-active: rgba(59, 130, 246, 0.65);
+  --backlog-drop-bg-active: rgba(59, 130, 246, 0.15);
+  --backlog-empty: rgba(15, 23, 42, 0.6);
+
+  --modal-bg: rgba(255, 255, 255, 0.9);
+  --modal-text: rgba(15, 23, 42, 0.92);
+  --modal-border: rgba(255, 255, 255, 0.6);
+  --modal-shadow: 0 34px 64px -44px rgba(15, 23, 42, 0.45);
+
+  --focus-overlay-bg: rgba(15, 23, 42, 0.1);
+  --focus-overlay-shadow: 0 40px 80px -60px rgba(15, 23, 42, 0.45);
+  --focus-overlay-text: rgba(15, 23, 42, 0.9);
+}
+
+:root[data-theme='dark'] {
+  background-color: #0b1324;
+  color: #f8fafc;
+
+  --toolbar-bg: rgba(15, 23, 42, 0.65);
+  --toolbar-border: rgba(59, 130, 246, 0.35);
+  --toolbar-shadow: 0 18px 36px -24px rgba(8, 47, 73, 0.6);
+  --toolbar-icon-color: rgba(148, 163, 184, 0.95);
+  --toolbar-icon-color-hover: #60a5fa;
+  --toolbar-hover-bg: rgba(37, 99, 235, 0.22);
+  --toolbar-input-bg: rgba(15, 23, 42, 0.9);
+  --toolbar-input-border: rgba(37, 99, 235, 0.45);
+  --toolbar-input-color: #e2e8f0;
+  --toolbar-focus-border: rgba(37, 99, 235, 0.75);
+
+  --priority-card-bg: rgba(15, 23, 42, 0.6);
+  --priority-card-text: rgba(226, 232, 240, 0.95);
+  --priority-card-shadow: 0 24px 52px -40px rgba(2, 6, 23, 0.85);
+  --priority-card-shadow-hover: 0 28px 60px -42px rgba(2, 6, 23, 0.9);
+  --priority-card-counter: #f1f5f9;
+  --priority-card-counter-muted: rgba(226, 232, 240, 0.65);
+
+  --pomodoro-bg: rgba(15, 23, 42, 0.75);
+  --pomodoro-text: rgba(226, 232, 240, 0.95);
+  --pomodoro-shadow: 0 28px 60px -40px rgba(2, 6, 23, 0.85);
+  --pomodoro-border: rgba(37, 99, 235, 0.35);
+  --pomodoro-track-bg: rgba(15, 23, 42, 0.35);
+  --pomodoro-task-color: rgba(148, 163, 184, 0.9);
+  --pomodoro-button-bg: rgba(59, 130, 246, 0.25);
+  --pomodoro-button-text: rgba(191, 219, 254, 0.95);
+  --pomodoro-button-shadow: 0 18px 32px -28px rgba(37, 99, 235, 0.45);
+  --pomodoro-button-shadow-hover: 0 22px 36px -28px rgba(37, 99, 235, 0.55);
+  --pomodoro-stat-bg: rgba(30, 41, 59, 0.65);
+  --pomodoro-input-bg: rgba(15, 23, 42, 0.85);
+
+  --fab-bg: linear-gradient(135deg, rgba(14, 116, 144, 0.95), rgba(37, 99, 235, 0.9));
+  --fab-shadow: 0 22px 44px -32px rgba(15, 118, 110, 0.7);
+  --fab-shadow-hover: 0 26px 48px -30px rgba(15, 118, 110, 0.85);
+
+  --task-card-bg: rgba(15, 23, 42, 0.7);
+  --task-card-border: rgba(59, 130, 246, 0.25);
+  --task-card-shadow: 0 18px 32px -22px rgba(2, 6, 23, 0.85);
+  --task-card-title: rgba(226, 232, 240, 0.95);
+  --task-card-title-done: rgba(148, 163, 184, 0.6);
+  --task-card-backlog-bg: rgba(14, 165, 233, 0.25);
+  --task-card-backlog-text: rgba(191, 219, 254, 0.95);
+  --task-card-backlog-bg-hover: rgba(14, 165, 233, 0.35);
+  --task-card-backlog-text-hover: rgba(191, 219, 254, 1);
+  --task-card-due-bg: rgba(15, 23, 42, 0.65);
+  --task-card-due-border: rgba(37, 99, 235, 0.35);
+  --task-card-due-text: rgba(148, 163, 184, 0.85);
+  --task-card-input-border: rgba(37, 99, 235, 0.35);
+  --task-card-input-bg: rgba(15, 23, 42, 0.75);
+  --task-card-input-text: rgba(226, 232, 240, 0.92);
+
+  --quadrant-bg: rgba(15, 23, 42, 0.68);
+  --quadrant-border: rgba(59, 130, 246, 0.35);
+  --quadrant-shadow: 0 28px 60px -40px rgba(2, 6, 23, 0.85);
+  --quadrant-shadow-hover: 0 32px 64px -38px rgba(2, 6, 23, 0.9);
+  --quadrant-title: rgba(226, 232, 240, 0.95);
+  --quadrant-subtitle: rgba(148, 163, 184, 0.78);
+  --quadrant-stats: rgba(148, 163, 184, 0.75);
+  --quadrant-stats-strong: rgba(226, 232, 240, 0.95);
+  --quadrant-toggle-bg: rgba(37, 99, 235, 0.25);
+  --quadrant-toggle-text: rgba(191, 219, 254, 0.95);
+  --quadrant-toggle-bg-hover: rgba(37, 99, 235, 0.35);
+  --quadrant-toggle-text-hover: rgba(255, 255, 255, 0.95);
+  --quadrant-drop-border: rgba(59, 130, 246, 0.35);
+  --quadrant-drop-bg: rgba(15, 23, 42, 0.45);
+  --quadrant-drop-border-active: rgba(56, 189, 248, 0.85);
+  --quadrant-drop-bg-active: rgba(15, 118, 110, 0.35);
+  --quadrant-empty: rgba(148, 163, 184, 0.7);
+
+  --backlog-bg: rgba(15, 23, 42, 0.72);
+  --backlog-border: rgba(59, 130, 246, 0.35);
+  --backlog-shadow: 0 26px 52px -36px rgba(2, 6, 23, 0.85);
+  --backlog-shadow-hover: 0 30px 60px -36px rgba(2, 6, 23, 0.9);
+  --backlog-title: rgba(226, 232, 240, 0.95);
+  --backlog-count: rgba(94, 234, 212, 0.95);
+  --backlog-checkbox-text: rgba(148, 163, 184, 0.8);
+  --backlog-toggle-bg: rgba(37, 99, 235, 0.25);
+  --backlog-toggle-text: rgba(191, 219, 254, 0.95);
+  --backlog-toggle-bg-hover: rgba(37, 99, 235, 0.35);
+  --backlog-toggle-text-hover: rgba(255, 255, 255, 0.98);
+  --backlog-drop-border: rgba(59, 130, 246, 0.35);
+  --backlog-drop-bg: rgba(30, 41, 59, 0.45);
+  --backlog-drop-border-active: rgba(56, 189, 248, 0.75);
+  --backlog-drop-bg-active: rgba(15, 118, 110, 0.3);
+  --backlog-empty: rgba(148, 163, 184, 0.75);
+
+  --modal-bg: rgba(15, 23, 42, 0.88);
+  --modal-text: rgba(226, 232, 240, 0.95);
+  --modal-border: rgba(37, 99, 235, 0.45);
+  --modal-shadow: 0 34px 64px -38px rgba(2, 6, 23, 0.9);
+
+  --focus-overlay-bg: rgba(15, 23, 42, 0.8);
+  --focus-overlay-shadow: 0 40px 80px -60px rgba(2, 6, 23, 0.95);
+  --focus-overlay-text: rgba(226, 232, 240, 0.95);
 }
 
 * {
@@ -18,6 +215,14 @@ body {
     radial-gradient(circle at 50% 100%, rgba(129, 140, 248, 0.25), transparent 55%),
     linear-gradient(180deg, rgba(241, 245, 255, 0.9), rgba(226, 232, 255, 0.6));
   background-attachment: fixed;
+}
+
+:root[data-theme='dark'] body {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(37, 99, 235, 0.18), transparent 45%),
+    radial-gradient(circle at 80% 0%, rgba(14, 165, 233, 0.22), transparent 40%),
+    radial-gradient(circle at 50% 100%, rgba(124, 58, 237, 0.18), transparent 50%),
+    linear-gradient(180deg, rgba(2, 6, 23, 0.95), rgba(15, 23, 42, 0.85));
 }
 
 button,

--- a/src/utils/exportFormats.ts
+++ b/src/utils/exportFormats.ts
@@ -1,0 +1,67 @@
+import { Quadrant, Task } from '../types';
+
+const QUADRANT_TITLES: Record<Quadrant, string> = {
+  backlog: 'Бэклог',
+  Q1: 'Q1 — Срочно + Важно',
+  Q2: 'Q2 — Несрочно + Важно',
+  Q3: 'Q3 — Срочно + Неважно',
+  Q4: 'Q4 — Несрочно + Неважно',
+};
+
+function formatTask(task: Task) {
+  const status = task.done ? 'x' : ' ';
+  const due = task.due ? ` _(до ${new Date(task.due).toLocaleString()})_` : '';
+  return `- [${status}] ${task.title}${due}`;
+}
+
+export function createMarkdown(tasks: Task[]): string {
+  const grouped: Record<Quadrant, Task[]> = { backlog: [], Q1: [], Q2: [], Q3: [], Q4: [] };
+  tasks.forEach((task) => {
+    const quadrant = grouped[task.quadrant] ? task.quadrant : 'backlog';
+    grouped[quadrant].push(task);
+  });
+
+  const sections = (Object.keys(grouped) as Quadrant[]).map((quadrant) => {
+    const items = grouped[quadrant].map(formatTask).join('\n');
+    return [`## ${QUADRANT_TITLES[quadrant]}`, items || '_Нет задач_'].join('\n');
+  });
+
+  const date = new Date();
+  const header = `# Список задач на ${date.toLocaleDateString('ru-RU', { day: 'numeric', month: 'long' })}`;
+
+  return [header, ...sections].join('\n\n');
+}
+
+export function createPrintableHtml(tasks: Task[]): string {
+  const markdown = createMarkdown(tasks);
+  const escaped = markdown
+    .split('\n')
+    .map((line) => line.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;'))
+    .join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <title>Список задач</title>
+    <style>
+      body {
+        font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        margin: 40px auto;
+        max-width: 720px;
+        line-height: 1.6;
+        color: #0f172a;
+      }
+      h1, h2 { color: #1e293b; }
+      code { font-family: inherit; }
+      ul { padding-left: 20px; }
+    </style>
+  </head>
+  <body>
+    <pre>${escaped}</pre>
+    <script>
+      setTimeout(() => window.print(), 400);
+    </script>
+  </body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- add a top-level priority overview, icon-only search/add controls, and quick-add modal
- implement Pomodoro timer support with focus mode, statistics, and theme toggle
- enhance drag-and-drop feedback and provide Markdown/PDF export utilities

## Testing
- npm run build
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc7989f5e48332b7abd1b58f6f787f