### PR TITLE
Redesign timer controls and backlog layout

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -2,51 +2,59 @@
   padding: clamp(20px, 4vw, 48px);
   display: flex;
   flex-direction: column;
-  gap: 28px;
-  max-width: 1280px;
+  gap: 32px;
+  max-width: 1420px;
   margin: 0 auto;
 }
 
-.hero {
+.header {
   display: grid;
-  gap: 20px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: clamp(16px, 4vw, 32px);
+  align-items: start;
 }
 
-.actionRow {
+.toolbar {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
+  gap: 14px;
   justify-content: flex-end;
 }
 
-.actionRow > * {
+.toolbar > * {
   flex-shrink: 0;
 }
 
-.topControls {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.layoutGrid {
+.mainContent {
   display: grid;
-  gap: 24px;
+  gap: clamp(20px, 3vw, 36px);
+  align-items: start;
 }
 
-@media (min-width: 1080px) {
-  .layoutGrid {
-    grid-template-columns: minmax(320px, 1fr) minmax(320px, 1fr);
-    align-items: start;
+@media (min-width: 1180px) {
+  .mainContent {
+    grid-template-columns: minmax(320px, 360px) minmax(0, 1fr);
   }
 }
 
-.boardRow {
+@media (max-width: 1179px) {
+  .sidebar {
+    position: static;
+  }
+}
+
+.sidebar {
   display: flex;
   flex-direction: column;
-  gap: 28px;
-  align-items: center;
+  gap: 18px;
+  position: sticky;
+  top: clamp(16px, 5vh, 48px);
+}
+
+.boardSection {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 }
 
 .alert {
@@ -84,4 +92,45 @@
   font-weight: 700;
   margin: 0;
   color: var(--focus-overlay-text);
+}
+
+.modalTabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px;
+  border-radius: 999px;
+  background: var(--toolbar-bg);
+  border: 1px solid var(--toolbar-border);
+  box-shadow: var(--toolbar-shadow);
+  margin-bottom: 18px;
+}
+
+.modalTabButton {
+  border: none;
+  background: none;
+  color: var(--toolbar-icon-color);
+  font-weight: 600;
+  padding: 8px 18px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.modalTabButton:hover,
+.modalTabButton:focus-visible {
+  background: var(--toolbar-hover-bg);
+  color: var(--toolbar-icon-color-hover);
+  outline: none;
+}
+
+.modalTabActive {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(14, 165, 233, 0.85));
+  color: #ffffff;
+  box-shadow: 0 12px 24px -16px rgba(37, 99, 235, 0.7);
+}
+
+.modalContentArea {
+  max-height: min(70vh, 620px);
+  overflow: auto;
 }

--- a/src/components/AddTaskButton.module.css
+++ b/src/components/AddTaskButton.module.css
@@ -2,8 +2,9 @@
   border: none;
   background: var(--fab-bg);
   color: var(--fab-fg);
-  padding: 10px;
-  border-radius: 18px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -18,7 +19,7 @@
 }
 
 .icon {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   fill: currentColor;
 }

--- a/src/components/BacklogList.module.css
+++ b/src/components/BacklogList.module.css
@@ -33,6 +33,9 @@
 .headerTitle {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 .headerActions {
@@ -54,7 +57,12 @@
   color: var(--backlog-count);
   font-size: 13px;
   display: block;
-  margin-top: 4px;
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 12px;
+  color: var(--backlog-subtitle);
 }
 
 .checkboxLabel {

--- a/src/components/BacklogList.tsx
+++ b/src/components/BacklogList.tsx
@@ -12,7 +12,7 @@ interface BacklogListProps {
   onDropTask: (taskId: string) => void;
   onUpdateTask: (taskId: string, updates: { title?: string; due?: string | null; done?: boolean }) => void;
   collapsed: boolean;
-  onToggleCollapse: () => void;
+  onToggleCollapse?: () => void;
   pomodoroControls?: {
     activeTaskId: string | null;
     mode: 'focus' | 'short_break' | 'long_break' | 'idle';
@@ -24,6 +24,12 @@ interface BacklogListProps {
     onResume: () => void;
     onReset: () => void;
   };
+  title?: string;
+  subtitle?: string;
+  collapsible?: boolean;
+  showCompletionToggle?: boolean;
+  emptyMessage?: string;
+  showQuadrantBadge?: boolean;
 }
 
 export function BacklogList({
@@ -34,8 +40,14 @@ export function BacklogList({
   onDropTask,
   onUpdateTask,
   collapsed,
-  onToggleCollapse,
+  onToggleCollapse = () => undefined,
   pomodoroControls,
+  title,
+  subtitle,
+  collapsible = true,
+  showCompletionToggle = true,
+  emptyMessage,
+  showQuadrantBadge = false,
 }: BacklogListProps) {
   const [isDragOver, setIsDragOver] = useState(false);
   const displayedCount = totalCount ?? tasks.length;
@@ -66,27 +78,32 @@ export function BacklogList({
     <section className={`${styles.container} ${collapsed ? styles.collapsed : ''}`.trim()}>
       <div className={styles.header}>
         <div className={styles.headerTitle}>
-          <h2 className={styles.title}>Бэклог</h2>
+          <h2 className={styles.title}>{title ?? 'Бэклог'}</h2>
           <span className={styles.count}>{displayedCount}</span>
+          {subtitle ? <p className={styles.subtitle}>{subtitle}</p> : null}
         </div>
         <div className={styles.headerActions}>
-          <button
-            type="button"
-            className={styles.toggleButton}
-            onClick={onToggleCollapse}
-            aria-expanded={!collapsed}
-            aria-controls={listId}
-          >
-            {collapsed ? 'Развернуть' : 'Свернуть'}
-          </button>
-          <label className={styles.checkboxLabel}>
-            <input
-              type="checkbox"
-              checked={hideCompleted}
-              onChange={(event) => onHideCompletedChange(event.target.checked)}
-            />
-            Скрыть выполненные
-          </label>
+          {collapsible ? (
+            <button
+              type="button"
+              className={styles.toggleButton}
+              onClick={onToggleCollapse}
+              aria-expanded={!collapsed}
+              aria-controls={listId}
+            >
+              {collapsed ? 'Развернуть' : 'Свернуть'}
+            </button>
+          ) : null}
+          {showCompletionToggle ? (
+            <label className={styles.checkboxLabel}>
+              <input
+                type="checkbox"
+                checked={hideCompleted}
+                onChange={(event) => onHideCompletedChange(event.target.checked)}
+              />
+              Скрыть выполненные
+            </label>
+          ) : null}
         </div>
       </div>
       {!collapsed && (
@@ -99,7 +116,9 @@ export function BacklogList({
         >
           {tasks.length === 0 ? (
             <div className={styles.empty}>
-              {hideCompleted
+              {emptyMessage
+                ? emptyMessage
+                : hideCompleted
                 ? 'Нет задач для отображения. Попробуйте отключить фильтр «Скрыть выполненные».'
                 : 'Все задачи распределены по квадрантам'}
             </div>
@@ -124,6 +143,7 @@ export function BacklogList({
                       }
                     : undefined
                 }
+                showQuadrantBadge={showQuadrantBadge}
               />
             ))
           )}

--- a/src/components/ImportPanel.module.css
+++ b/src/components/ImportPanel.module.css
@@ -1,14 +1,14 @@
 .panel {
-  background: rgba(255, 255, 255, 0.32);
-  border-radius: 22px;
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 20px;
   padding: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.28);
   display: flex;
   flex-direction: column;
   gap: 14px;
-  box-shadow: 0 30px 60px -40px rgba(15, 23, 42, 0.45);
-  backdrop-filter: blur(28px) saturate(140%);
-  -webkit-backdrop-filter: blur(28px) saturate(140%);
+  backdrop-filter: blur(26px) saturate(140%);
+  -webkit-backdrop-filter: blur(26px) saturate(140%);
+  width: 100%;
 }
 
 .label {

--- a/src/components/ManualTaskForm.module.css
+++ b/src/components/ManualTaskForm.module.css
@@ -12,6 +12,13 @@
   color: #0f172a;
 }
 
+.formModal {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  box-shadow: none;
+  width: 100%;
+}
+
 .header {
   display: flex;
   align-items: center;
@@ -19,10 +26,26 @@
   gap: 12px;
 }
 
+.modalHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+}
+
 .title {
   margin: 0;
   font-size: 17px;
   font-weight: 700;
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.85);
 }
 
 .feedback {

--- a/src/components/ManualTaskForm.tsx
+++ b/src/components/ManualTaskForm.tsx
@@ -15,6 +15,7 @@ interface ManualTaskFormProps {
   onCreateTask: (task: { title: string; due: string | null; quadrant: Quadrant }) => void;
   initialQuadrant?: Quadrant;
   focusTrigger?: number;
+  variant?: 'standalone' | 'modal';
 }
 
 const QUADRANT_OPTIONS: Array<{ value: Quadrant; label: string }> = [
@@ -26,7 +27,7 @@ const QUADRANT_OPTIONS: Array<{ value: Quadrant; label: string }> = [
 ];
 
 export const ManualTaskForm = forwardRef<HTMLFormElement, ManualTaskFormProps>(
-  ({ onCreateTask, initialQuadrant = 'backlog', focusTrigger }, ref) => {
+  ({ onCreateTask, initialQuadrant = 'backlog', focusTrigger, variant = 'standalone' }, ref) => {
     const [title, setTitle] = useState('');
     const [due, setDue] = useState('');
     const [quadrant, setQuadrant] = useState<Quadrant>(initialQuadrant);
@@ -102,9 +103,9 @@ export const ManualTaskForm = forwardRef<HTMLFormElement, ManualTaskFormProps>(
     };
 
     return (
-      <form ref={ref} className={styles.form} onSubmit={handleSubmit}>
-        <div className={styles.header}>
-          <h2 className={styles.title}>Быстрое добавление</h2>
+      <form ref={ref} className={`${styles.form} ${variant === 'modal' ? styles.formModal : ''}`.trim()} onSubmit={handleSubmit}>
+        <div className={variant === 'modal' ? styles.modalHeader : styles.header}>
+          <h2 className={variant === 'modal' ? styles.modalTitle : styles.title}>Быстрое добавление</h2>
           {feedback ? <span className={styles.feedback}>{feedback}</span> : null}
         </div>
         <label className={styles.label}>

--- a/src/components/Modal.module.css
+++ b/src/components/Modal.module.css
@@ -12,7 +12,7 @@
 }
 
 .container {
-  width: min(560px, 100%);
+  width: min(680px, 100%);
   background: var(--modal-bg);
   color: var(--modal-text);
   border-radius: 24px;

--- a/src/components/PomodoroBar.module.css
+++ b/src/components/PomodoroBar.module.css
@@ -24,6 +24,16 @@
   }
 }
 
+@media (max-width: 720px) {
+  .controls {
+    align-items: flex-start;
+  }
+
+  .primaryControls {
+    justify-content: flex-start;
+  }
+}
+
 .timerInfo {
   display: flex;
   flex-direction: column;
@@ -91,8 +101,58 @@
 
 .controls {
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+  width: 100%;
+}
+
+.primaryControls {
+  display: inline-flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.iconControl {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.92), rgba(59, 130, 246, 0.88));
+  color: #ffffff;
+  box-shadow: 0 16px 28px -20px rgba(37, 99, 235, 0.9);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.iconControl:hover,
+.iconControl:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 32px -18px rgba(37, 99, 235, 0.95);
+  outline: none;
+}
+
+.iconControl:disabled,
+.iconControlDisabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.iconControlSvg {
+  width: 20px;
+  height: 20px;
+  fill: currentColor;
+}
+
+.secondaryControls {
+  display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  justify-content: flex-end;
 }
 
 .controlButton {
@@ -135,6 +195,18 @@
 
 .settingsToggle:hover {
   background: var(--pomodoro-button-bg);
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .bottomRow {

--- a/src/components/PomodoroBar.tsx
+++ b/src/components/PomodoroBar.tsx
@@ -115,31 +115,73 @@ export function PomodoroBar({
           </div>
         </div>
         <div className={styles.controls}>
-          {runState === 'running' ? (
-            <button type="button" className={styles.controlButton} onClick={onPause}>
-              Пауза (P)
+          <div className={styles.primaryControls}>
+            {runState === 'running' ? (
+              <>
+                <button type="button" className={styles.iconControl} onClick={onPause} aria-label="Пауза таймера">
+                  <span className={styles.visuallyHidden}>Пауза таймера</span>
+                  <svg viewBox="0 0 24 24" aria-hidden className={styles.iconControlSvg}>
+                    <path d="M9 4a1 1 0 0 1 1 1v14a1 1 0 1 1-2 0V5a1 1 0 0 1 1-1Zm6 0a1 1 0 0 1 1 1v14a1 1 0 1 1-2 0V5a1 1 0 0 1 1-1Z" />
+                  </svg>
+                </button>
+                <button type="button" className={styles.iconControl} onClick={onReset} aria-label="Остановить таймер">
+                  <span className={styles.visuallyHidden}>Остановить таймер</span>
+                  <svg viewBox="0 0 24 24" aria-hidden className={styles.iconControlSvg}>
+                    <path d="M7 5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2Z" />
+                  </svg>
+                </button>
+              </>
+            ) : runState === 'paused' ? (
+              <>
+                <button
+                  type="button"
+                  className={`${styles.iconControl} ${!activeTask ? styles.iconControlDisabled : ''}`.trim()}
+                  onClick={onResume}
+                  aria-label="Продолжить таймер"
+                  disabled={!activeTask}
+                >
+                  <span className={styles.visuallyHidden}>Продолжить таймер</span>
+                  <svg viewBox="0 0 24 24" aria-hidden className={styles.iconControlSvg}>
+                    <path d="M8.25 4.64a1 1 0 0 1 1.49-.86l9 5.36a1 1 0 0 1 0 1.72l-9 5.36A1 1 0 0 1 8 15.36V4.64Z" />
+                  </svg>
+                </button>
+                <button type="button" className={styles.iconControl} onClick={onReset} aria-label="Остановить таймер">
+                  <span className={styles.visuallyHidden}>Остановить таймер</span>
+                  <svg viewBox="0 0 24 24" aria-hidden className={styles.iconControlSvg}>
+                    <path d="M7 5a2 2 0 0 1 2-2h6a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2Z" />
+                  </svg>
+                </button>
+              </>
+            ) : (
+              <button
+                type="button"
+                className={`${styles.iconControl} ${!activeTask ? styles.iconControlDisabled : ''}`.trim()}
+                onClick={onResume}
+                aria-label="Запустить таймер"
+                disabled={!activeTask}
+              >
+                <span className={styles.visuallyHidden}>Запустить таймер</span>
+                <svg viewBox="0 0 24 24" aria-hidden className={styles.iconControlSvg}>
+                  <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm0 2a8 8 0 1 1 0 16 8 8 0 0 1 0-16Zm-.75 2.5a.75.75 0 0 1 1.5 0V12l3.5 2.1a.75.75 0 1 1-.75 1.3l-4-2.4a.75.75 0 0 1-.37-.64Z" />
+                </svg>
+              </button>
+            )}
+          </div>
+          <div className={styles.secondaryControls}>
+            <button type="button" className={styles.controlButton} onClick={onSkip} disabled={mode === 'idle'}>
+              Следующий
             </button>
-          ) : (
-            <button type="button" className={styles.controlButton} onClick={onResume} disabled={!activeTask}>
-              Старт (P)
+            <button
+              type="button"
+              className={`${styles.controlButton} ${focusModeEnabled ? styles.controlActive : ''}`.trim()}
+              onClick={onToggleFocusMode}
+            >
+              Фокус-режим
             </button>
-          )}
-          <button type="button" className={styles.controlButton} onClick={onSkip} disabled={mode === 'idle'}>
-            Следующий
-          </button>
-          <button type="button" className={styles.controlButton} onClick={onReset}>
-            Сброс (R)
-          </button>
-          <button
-            type="button"
-            className={`${styles.controlButton} ${focusModeEnabled ? styles.controlActive : ''}`.trim()}
-            onClick={onToggleFocusMode}
-          >
-            Фокус-режим
-          </button>
-          <button type="button" className={styles.settingsToggle} onClick={() => setShowSettings((value) => !value)}>
-            Настройки
-          </button>
+            <button type="button" className={styles.settingsToggle} onClick={() => setShowSettings((value) => !value)}>
+              Настройки
+            </button>
+          </div>
         </div>
       </div>
       <div className={styles.bottomRow}>

--- a/src/components/QuadrantBoard.module.css
+++ b/src/components/QuadrantBoard.module.css
@@ -1,22 +1,21 @@
 .board {
   display: grid;
   gap: 24px;
-  justify-content: center;
-  grid-template-columns: minmax(260px, 1fr);
-  width: min(100%, 760px);
+  grid-template-columns: minmax(0, 1fr);
+  width: 100%;
 }
 
 @media (min-width: 768px) {
   .board {
-    grid-template-columns: repeat(2, minmax(280px, 360px));
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
 .zone {
   background: var(--quadrant-bg);
-  border-radius: 24px;
+  border-radius: 26px;
   border: 1px solid var(--quadrant-border);
-  padding: 18px;
+  padding: 20px;
   box-shadow: var(--quadrant-shadow);
   display: flex;
   flex-direction: column;

--- a/src/components/SearchBar.module.css
+++ b/src/components/SearchBar.module.css
@@ -9,13 +9,15 @@
   box-shadow: var(--toolbar-shadow);
   transition: width 0.3s ease, background 0.3s ease;
   width: auto;
+  min-height: 48px;
 }
 
 .iconButton {
   border: none;
   background: none;
   cursor: pointer;
-  padding: 8px;
+  width: 36px;
+  height: 36px;
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
@@ -31,8 +33,8 @@
 }
 
 .icon {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   fill: currentColor;
 }
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -36,7 +36,9 @@ export function SearchBar({ value, expanded, onChange, onClear, onToggle, inputR
         onClick={() => onToggle(!expanded)}
       >
         <svg viewBox="0 0 24 24" className={styles.icon} aria-hidden>
-          <path d="M21 21a1 1 0 0 1-1.71.71l-4.92-4.93a7 7 0 1 1 1.41-1.41l4.93 4.92A1 1 0 0 1 21 21Zm-10-4a5 5 0 1 0 0-10 5 5 0 0 0 0 10Z" />
+          <path
+            d="M10.75 2.5a8.25 8.25 0 0 1 6.4 13.52l4.17 4.16a1.35 1.35 0 0 1-1.91 1.91l-4.16-4.17A8.25 8.25 0 1 1 10.75 2.5Zm0 2.7a5.55 5.55 0 1 0 0 11.1 5.55 5.55 0 0 0 0-11.1Z"
+          />
         </svg>
       </button>
       <div className={styles.inputContainer}>
@@ -45,7 +47,7 @@ export function SearchBar({ value, expanded, onChange, onClear, onToggle, inputR
           className={styles.searchInput}
           value={value}
           onChange={(event) => onChange(event.target.value)}
-          placeholder="Поиск по бэклогу"
+          placeholder="Поиск по всем задачам"
           type="search"
           aria-hidden={!expanded}
         />

--- a/src/components/TaskCard.module.css
+++ b/src/components/TaskCard.module.css
@@ -31,6 +31,35 @@
   gap: 12px;
 }
 
+.quadrantBadge {
+  align-self: flex-start;
+  margin-left: auto;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #ffffff;
+  box-shadow: 0 10px 20px -14px rgba(15, 23, 42, 0.55);
+}
+
+.quadrantQ1 {
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.9), rgba(22, 163, 74, 0.85));
+}
+
+.quadrantQ2 {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.9), rgba(37, 99, 235, 0.85));
+}
+
+.quadrantQ3 {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.9), rgba(8, 145, 178, 0.85));
+}
+
+.quadrantQ4 {
+  background: linear-gradient(135deg, rgba(168, 85, 247, 0.9), rgba(124, 58, 237, 0.85));
+}
+
 .doneToggle {
   flex-shrink: 0;
   display: inline-flex;
@@ -201,34 +230,47 @@
 
 .pomodoroActions {
   display: flex;
-  gap: 8px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
-.pomodoroButton,
-.pomodoroButtonSecondary {
+.pomodoroIconButton,
+.pomodoroIconButtonSecondary {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
   border: none;
-  border-radius: 999px;
-  padding: 6px 12px;
-  font-size: 13px;
-  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
-.pomodoroButton {
-  background: rgba(255, 255, 255, 0.2);
+.pomodoroIconButton {
+  background: rgba(255, 255, 255, 0.24);
   color: white;
+  box-shadow: 0 16px 28px -20px rgba(15, 23, 42, 0.35);
 }
 
-.pomodoroButtonSecondary {
-  background: rgba(15, 23, 42, 0.18);
+.pomodoroIconButtonSecondary {
+  background: rgba(15, 23, 42, 0.2);
   color: white;
+  box-shadow: 0 16px 28px -22px rgba(15, 23, 42, 0.4);
 }
 
-.pomodoroButton:hover,
-.pomodoroButtonSecondary:hover {
-  transform: translateY(-1px);
+.pomodoroIconButton:hover,
+.pomodoroIconButton:focus-visible,
+.pomodoroIconButtonSecondary:hover,
+.pomodoroIconButtonSecondary:focus-visible {
+  transform: translateY(-2px);
+  outline: none;
+}
+
+.pomodoroIconSvg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
 .pomodoroFocus {

--- a/src/components/ThemeToggleButton.module.css
+++ b/src/components/ThemeToggleButton.module.css
@@ -1,9 +1,11 @@
+
 .button {
   border: none;
   background: none;
   cursor: pointer;
-  padding: 8px;
-  border-radius: 12px;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -18,7 +20,7 @@
 }
 
 .icon {
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   fill: currentColor;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,7 @@
   --backlog-shadow-hover: 0 32px 60px -42px rgba(15, 23, 42, 0.5);
   --backlog-title: rgba(15, 23, 42, 0.9);
   --backlog-count: rgba(14, 116, 144, 0.9);
+  --backlog-subtitle: rgba(15, 23, 42, 0.55);
   --backlog-checkbox-text: rgba(15, 23, 42, 0.65);
   --backlog-toggle-bg: rgba(15, 23, 42, 0.08);
   --backlog-toggle-text: rgba(15, 23, 42, 0.75);
@@ -181,6 +182,7 @@
   --backlog-shadow-hover: 0 30px 60px -36px rgba(2, 6, 23, 0.9);
   --backlog-title: rgba(226, 232, 240, 0.95);
   --backlog-count: rgba(94, 234, 212, 0.95);
+  --backlog-subtitle: rgba(148, 163, 184, 0.8);
   --backlog-checkbox-text: rgba(148, 163, 184, 0.8);
   --backlog-toggle-bg: rgba(37, 99, 235, 0.25);
   --backlog-toggle-text: rgba(191, 219, 254, 0.95);


### PR DESCRIPTION
## Summary
- relocate the toolbar with search, add, and theme controls to the header and enlarge the backlog/board layout
- integrate task creation and import into a single modal with tabbed navigation and add search across all tasks with quadrant badges
- replace textual pomodoro controls with compact icon buttons both in the timer bar and task cards while refining supporting styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccef657054833285210428b22f8bca