### PR TITLE
Improve task import resilience and pomodoro telemetry

### DIFF
--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,143 @@
+import { RefObject, useEffect } from 'react';
+import { Quadrant } from '../types';
+
+type RunState = 'running' | 'paused' | 'stopped';
+
+interface PomodoroShortcutControls {
+  activeTaskId: string | null;
+  runState: RunState;
+  pause: () => void;
+  resume: () => void;
+  reset: () => void;
+}
+
+interface KeyboardShortcutOptions {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+  setSearchExpanded: (value: boolean) => void;
+  searchInputRef: RefObject<HTMLInputElement>;
+  openImportModal: () => void;
+  importTextareaRef: RefObject<HTMLTextAreaElement>;
+  pomodoro: PomodoroShortcutControls;
+  moveTask: (taskId: string, quadrant: Quadrant) => void;
+  onResetFocusMode: () => void;
+}
+
+export function useKeyboardShortcuts({
+  searchQuery,
+  setSearchQuery,
+  setSearchExpanded,
+  searchInputRef,
+  openImportModal,
+  importTextareaRef,
+  pomodoro,
+  moveTask,
+  onResetFocusMode,
+}: KeyboardShortcutOptions) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const key = event.key;
+      const normalizedKey = key.toLowerCase();
+      const target = event.target as HTMLElement | null;
+      const isEditableTarget =
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.tagName === 'SELECT' ||
+          target.isContentEditable);
+
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        if (normalizedKey === 'escape' && searchQuery) {
+          event.preventDefault();
+          setSearchQuery('');
+          setSearchExpanded(false);
+        }
+        return;
+      }
+
+      if (normalizedKey === '/') {
+        event.preventDefault();
+        setSearchExpanded(true);
+        window.requestAnimationFrame(() => {
+          searchInputRef.current?.focus();
+          searchInputRef.current?.select();
+        });
+        return;
+      }
+
+      if (normalizedKey === 'escape') {
+        if (searchQuery) {
+          event.preventDefault();
+          setSearchQuery('');
+          setSearchExpanded(false);
+        }
+        return;
+      }
+
+      if (isEditableTarget) {
+        return;
+      }
+
+      if (normalizedKey === 'p') {
+        event.preventDefault();
+        if (pomodoro.runState === 'running') {
+          pomodoro.pause();
+        } else if (pomodoro.activeTaskId) {
+          pomodoro.resume();
+        }
+        return;
+      }
+
+      if (normalizedKey === 'r') {
+        event.preventDefault();
+        pomodoro.reset();
+        onResetFocusMode();
+        return;
+      }
+
+      if (normalizedKey === 'i') {
+        event.preventDefault();
+        openImportModal();
+        window.requestAnimationFrame(() => {
+          const textarea = importTextareaRef.current;
+          textarea?.focus();
+          textarea?.select?.();
+        });
+        return;
+      }
+
+      if (['0', '1', '2', '3', '4'].includes(key)) {
+        const activeElement = document.activeElement as HTMLElement | null;
+        const taskId = activeElement?.dataset.taskId;
+        if (!taskId) {
+          return;
+        }
+
+        const targetQuadrant: Quadrant =
+          key === '0' ? 'backlog' : key === '1' ? 'Q1' : key === '2' ? 'Q2' : key === '3' ? 'Q3' : 'Q4';
+
+        event.preventDefault();
+        moveTask(taskId, targetQuadrant);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [
+    importTextareaRef,
+    moveTask,
+    onResetFocusMode,
+    openImportModal,
+    pomodoro.activeTaskId,
+    pomodoro.pause,
+    pomodoro.reset,
+    pomodoro.resume,
+    pomodoro.runState,
+    searchInputRef,
+    searchQuery,
+    setSearchExpanded,
+    setSearchQuery,
+  ]);
+}

--- a/src/test/exportFormats.test.ts
+++ b/src/test/exportFormats.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { createMarkdown } from '../utils/exportFormats';
+import { formatDate } from '../utils/date';
+import { Task } from '../types';
+
+describe('export formats', () => {
+  it('formats due dates using formatDate helper', () => {
+    const task: Task = {
+      id: 'task-1',
+      title: 'Check deadline',
+      due: '1. 10. 2025 at 0:00',
+      quadrant: 'Q1',
+      done: false,
+      createdAt: '2024-01-01T00:00:00.000Z',
+      completedAt: null,
+      timeSpentSeconds: 0,
+    };
+
+    const markdown = createMarkdown([task]);
+    expect(markdown).toContain(`до ${formatDate(task.due)}`);
+    expect(markdown).not.toContain('Invalid Date');
+  });
+});

--- a/src/test/pomodoroTimer.test.ts
+++ b/src/test/pomodoroTimer.test.ts
@@ -1,0 +1,47 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePomodoroTimer } from '../hooks/usePomodoroTimer';
+
+describe('usePomodoroTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('records completed session duration despite runtime config changes', () => {
+    const { result } = renderHook(() => usePomodoroTimer());
+
+    act(() => {
+      result.current.updateConfig({ focusMinutes: 1, shortBreakMinutes: 1, longBreakMinutes: 1 });
+    });
+
+    act(() => {
+      result.current.start('task-1');
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    act(() => {
+      result.current.updateConfig({ focusMinutes: 2 });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    const sessions = result.current.stats.completedSessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toMatchObject({
+      taskId: 'task-1',
+      durationSeconds: 60,
+    });
+    expect(result.current.stats.completedPerTask['task-1']).toBe(1);
+  });
+});

--- a/src/test/useKeyboardShortcuts.test.tsx
+++ b/src/test/useKeyboardShortcuts.test.tsx
@@ -1,0 +1,178 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useKeyboardShortcuts } from '../hooks/useKeyboardShortcuts';
+
+type ShortcutProps = Parameters<typeof useKeyboardShortcuts>[0];
+
+describe('useKeyboardShortcuts', () => {
+  let originalRaf: typeof window.requestAnimationFrame;
+
+  beforeEach(() => {
+    originalRaf = window.requestAnimationFrame;
+    window.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    }) as typeof window.requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRaf;
+    document.body.innerHTML = '';
+  });
+
+  it('focuses search input on / and clears query on escape', () => {
+    const searchInput = document.createElement('input');
+    document.body.appendChild(searchInput);
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+
+    const setSearchQuery = vi.fn();
+    const setSearchExpanded = vi.fn();
+    const openImportModal = vi.fn();
+    const moveTask = vi.fn();
+    const pause = vi.fn();
+    const resume = vi.fn();
+    const reset = vi.fn();
+    const onResetFocusMode = vi.fn();
+
+    const initialProps: ShortcutProps = {
+      searchQuery: '',
+      setSearchQuery,
+      setSearchExpanded,
+      searchInputRef: { current: searchInput },
+      openImportModal,
+      importTextareaRef: { current: textarea },
+      pomodoro: { activeTaskId: 'task-1', runState: 'paused' as const, pause, resume, reset },
+      moveTask,
+      onResetFocusMode,
+    };
+
+    const { rerender } = renderHook((props: ShortcutProps) => useKeyboardShortcuts(props), { initialProps });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '/' }));
+    });
+
+    expect(setSearchExpanded).toHaveBeenCalledWith(true);
+    expect(document.activeElement).toBe(searchInput);
+
+    rerender({ ...initialProps, searchQuery: 'foo' });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+
+    expect(setSearchQuery).toHaveBeenCalledWith('');
+    expect(setSearchExpanded).toHaveBeenCalledWith(false);
+  });
+
+  it('controls pomodoro playback with p and r', () => {
+    const searchInput = document.createElement('input');
+    document.body.appendChild(searchInput);
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+
+    const pause = vi.fn();
+    const resume = vi.fn();
+    const reset = vi.fn();
+    const setSearchQuery = vi.fn();
+    const setSearchExpanded = vi.fn();
+    const moveTask = vi.fn();
+    const onResetFocusMode = vi.fn();
+    const openImportModal = vi.fn();
+
+    const { rerender } = renderHook((props: ShortcutProps) => useKeyboardShortcuts(props), {
+      initialProps: {
+        searchQuery: '',
+        setSearchQuery,
+        setSearchExpanded,
+        searchInputRef: { current: searchInput },
+        openImportModal,
+        importTextareaRef: { current: textarea },
+        pomodoro: { activeTaskId: 'task-1', runState: 'running', pause, resume, reset },
+        moveTask,
+        onResetFocusMode,
+      },
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+    });
+
+    expect(pause).toHaveBeenCalledTimes(1);
+
+    rerender({
+      searchQuery: '',
+      setSearchQuery,
+      setSearchExpanded,
+      searchInputRef: { current: searchInput },
+      openImportModal,
+      importTextareaRef: { current: textarea },
+      pomodoro: { activeTaskId: 'task-1', runState: 'paused', pause, resume, reset },
+      moveTask,
+      onResetFocusMode,
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'p' }));
+    });
+
+    expect(resume).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'r' }));
+    });
+
+    expect(reset).toHaveBeenCalledTimes(1);
+    expect(onResetFocusMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens import modal and moves tasks with digit keys', () => {
+    const searchInput = document.createElement('input');
+    document.body.appendChild(searchInput);
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    const focusButton = document.createElement('button');
+    focusButton.dataset.taskId = 'task-42';
+    document.body.appendChild(focusButton);
+    focusButton.focus();
+
+    const pause = vi.fn();
+    const resume = vi.fn();
+    const reset = vi.fn();
+    const setSearchQuery = vi.fn();
+    const setSearchExpanded = vi.fn();
+    const moveTask = vi.fn();
+    const onResetFocusMode = vi.fn();
+    const openImportModal = vi.fn();
+
+    renderHook((props: ShortcutProps) => useKeyboardShortcuts(props), {
+      initialProps: {
+        searchQuery: '',
+        setSearchQuery,
+        setSearchExpanded,
+        searchInputRef: { current: searchInput },
+        openImportModal,
+        importTextareaRef: { current: textarea },
+        pomodoro: { activeTaskId: null, runState: 'stopped', pause, resume, reset },
+        moveTask,
+        onResetFocusMode,
+      },
+    });
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'i' }));
+    });
+
+    expect(openImportModal).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(textarea);
+
+    focusButton.focus();
+
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: '1' }));
+    });
+
+    expect(moveTask).toHaveBeenCalledWith('task-42', 'Q1');
+  });
+});

--- a/src/utils/exportFormats.ts
+++ b/src/utils/exportFormats.ts
@@ -1,4 +1,5 @@
 import { Quadrant, Task } from '../types';
+import { formatDate } from './date';
 
 const QUADRANT_TITLES: Record<Quadrant, string> = {
   backlog: 'Бэклог',
@@ -10,7 +11,7 @@ const QUADRANT_TITLES: Record<Quadrant, string> = {
 
 function formatTask(task: Task) {
   const status = task.done ? 'x' : ' ';
-  const due = task.due ? ` _(до ${new Date(task.due).toLocaleString()})_` : '';
+  const due = task.due ? ` _(до ${formatDate(task.due)})_` : '';
   return `- [${status}] ${task.title}${due}`;
 }
 


### PR DESCRIPTION
## Summary
- harden JSON import by skipping trailing commas inside strings and preserving existing task metadata during partial updates
- add completed session logging to the pomodoro timer and consume it in App to credit accurate time while introducing a reusable keyboard shortcut hook
- reuse formatDate when exporting markdown and cover new behaviors with Vitest suites for imports, exports, pomodoro, and hotkeys

## Testing
- `npx tsc --noEmit`
- `npm run test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68cd13244a9883329888cf2cf7a1dae5